### PR TITLE
Re-organized 'example sbatch scripts', removed incorrect refs and links

### DIFF
--- a/docs/midway23/midway_submitting_jobs.md
+++ b/docs/midway23/midway_submitting_jobs.md
@@ -1,10 +1,10 @@
 # Submitting Jobs
-This page describes how users can submit jobs (either Interactive or Batch) to Midway. The flowchart below illustrates the main steps in that process.  
+This page describes how users can submit jobs (either Interactive or Batch) to Midway. The flowchart below illustrates the main steps in that process. [SLURM](https://slurm.schedmd.com/documentation.html) is the resource manager for all the clusters.
 
 ![Jobs Overview](img/running_jobs/jobs_overview.png)
 
 ## Interactive Jobs
-Interactive jobs are the most intutive way to use Midway, as they allow you to interact with the program running on compute node/s (e.g., execute cells in a Jupyter Notebook) in real-time. This is great for exploratory work or troubleshooting. An interactive job will persist until you disconnect from the compute node, or until you reach the maximum requested time.  
+Interactive jobs are the most intuitive way to use Midway, as they allow you to interact with the program running on compute node/s (e.g., execute cells in a Jupyter Notebook) in real-time. This is great for exploratory work or troubleshooting. An interactive job will persist until you disconnect from the compute node, or until you reach the maximum requested time.  
 To request an interactive job, run the following command while connected to a login node:  
 ```
 sinteractive
@@ -25,18 +25,21 @@ There are many additional options for the sinteractive command, including option
 ```
 sinteractive --exclusive --partition=broadwl --nodes=2 --time=08:00:00
 ```
-For more details about these and other useful parameters, read below about the `sbatch` command. *All options available in the sbatch command are also available for the sinteractive command.*
+For more details about these and other useful parameters, read below about the `sbatch` command. *All options available in the `sbatch` command are also available for the `sinteractive` command.*
 
 ### Debug QOS 
 There is a debug QOS (Quality of Service) setup to help users quickly access some resources to debug or test their code before submitting their jobs to the main partition. The debug QOS will allow you to run one job and get up to 4 cores for 15 minutes without consuming SUs. To use the debug QOS, you have to specify `--time` as 15 minutes or less. For example, to get 2 cores for 15 minutes, you could run:
 ```
 sinteractive --qos=debug --time=00:15:00 --ntasks=2
 ```
-
+You can find out the available `qos` for your account with the command `rcchelp`
+```
+rcchelp qos
+```
 
 ## Batch Jobs
 
-The `sbatch` command is used to request computing resources on the Midway clusters. Rather than specify all the options in the command line, users typically write an “sbatch script” that contains all the commands and parameters neccessary to run a program on the cluster. Batch jobs are non-interactive, as you submit a program to be executed on a compute node with no possibility of interactivity. A batch job doesn't require you to be logged in after submission, and ends when either (1) the program is finished running, (2) job's maximum time is reached, or (3) an error occurs.
+The `sbatch` command is used to request computing resources on the Midway clusters. Rather than specifying all the options in the command line, users typically write a sbatch script that contains all the commands and parameters neccessary to run a program on the cluster. Batch jobs are non-interactive, as you submit a program to be executed on a compute node with no possibility of interactivity. A batch job doesn't require you to be logged in after submission, and ends when either (1) the program is finished running, (2) job's maximum time is reached, or (3) an error occurs.
 
 ### SBATCH Scripts
 
@@ -49,7 +52,7 @@ Here is an example of a Midway2 sbatch script:
 #SBATCH --job-name=example_sbatch
 #SBATCH --output=example_sbatch.out
 #SBATCH --error=example_sbatch.err
-#SBATCH --time=00:05:00
+#SBATCH --time=03:30:00
 #SBATCH --partition=broadwl
 #SBATCH --nodes=4
 #SBATCH --ntasks-per-node=14
@@ -64,14 +67,14 @@ And here is an explanation of what each of these parameters does:
 
 |  <div style="width:220px">Option</div>      | Description |
 | ----------- | ----------- |
-| `--job-name=example_sbatch`      | Assigns name `example_sbatch` to the job.       |
-| `--output=example_sbatch.out`   | Writes console output to file `example_sbatch.out`.        |
-| `--error=example_sbatch.err`   | Writes error messages to file `example_sbatch.err`.        |
-| `--time=00:05:00`   | Reserves the computing resources for 5 minutes (or less if program completes before 5 min).  | 
+| `--job-name=my_run`     | Assigns name `my-run` to the job.       |
+| `--output=my_run.out`   | Writes console output to file `my_run.out`.        |
+| `--error=my_run.err`    | Writes error messages to file `my_run.err`.        |
+| `--time=03:30:00`       | Reserves the computing resources for 3 hours and 30 minutes max (actual time may be shorter if your run completes before this wall time).  | 
 | `--partition=broadwl`   | Requests compute nodes from the broadwell partition on the Midway2 cluster. |
-| `--nodes=4`   | Requests 4 compute nodes |
-| `--ntasks-per-node=14`   | Requests 14 cores (CPUs) per node, for a total of 14 * 4 = 56 cores. |
-| `--mem-per-cpu=2000`   | Requests 2000 MB (2 GB) of memory (RAM) per core, for a total of 2 * 14 = 28 GB per node. |
+| `--nodes=4`             | Requests 4 compute nodes |
+| `--ntasks-per-node=14`  | Requests 14 cores (CPUs) per node, for a total of 14 * 4 = 56 cores. |
+| `--mem-per-cpu=2000`    | Requests 2000 MB (2 GB) of memory (RAM) per core, for a total of 2 * 14 = 28 GB per node. |
 
 In this example, we have requested 4 compute nodes with 14 CPUs each. Therefore, we have requested a total of 56 CPUs for running our program. The last two lines of the script load the OpenMPI module and launch the MPI-based executable that we have called `hello-mpi`.
 
@@ -85,7 +88,7 @@ or more generally:
 ```
 sbatch ./<your_sbatch_file>
 ```
-
+<!---
 ### Example Submission Scripts
 
 Here are some example sbatch job submission scripts that demonstrate the different options and jobs types you make wish to use.
@@ -176,5 +179,8 @@ Here are some example sbatch job submission scripts that demonstrate the differe
     export OMP_NUM_THREADS=$SLURM_CPUS_PER_TASK
     python training.py
     ```
+--->
+
+See [Example batch scripts](./examples/example_job_scripts.md) for typical use cases.
 
 You can find more example sbatch submission scripts in the [RCC SLURM workshop materials](https://github.com/rcc-uchicago/SLURM_WORKSHOP)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -18,7 +18,7 @@ nav:
       - Overview: midway23/midway_jobs_overview.md
       - Submitting Jobs: midway23/midway_submitting_jobs.md
       - Managing Jobs: midway23/midway_job_management.md
-      - Example Job Submission Scripts: midway23/examples/example_job_scripts.md
+      - Example Batch Job Scripts: midway23/examples/example_job_scripts.md
     - "Software":
       - Overview: midway23/software/midway_software_overview.md
       - "Commonly Used Applications":


### PR DESCRIPTION
This PR is to address issue #16 