### PR TITLE
add tutorial pages 

### DIFF
--- a/docs/midway23/midway_data_transfer.md
+++ b/docs/midway23/midway_data_transfer.md
@@ -160,7 +160,7 @@ RCC provides web access to data on their storage system via public_html director
 |----------------------------------------------|-----------------------------------------------------------|
 | /home/[your_CNetID]/public_html/research.dat | http://users.rcc.uchicago.edu/~[your_CNetID]/research.dat |
 
-Ensure your home directory and `public_html` have the execute [permissions](midway_file_permissions.md). If the folder `public_html` does not exist, create it. 
+Ensure your home directory and `public_html` have the execute [permissions](midway_data_sharing.md). If the folder `public_html` does not exist, create it. 
 Optionally, ensure public_html has read permissions if you would like to allow indexing.
 
 You may set these permissions using the following commands:

--- a/docs/midwayR3/data-transfer.md
+++ b/docs/midwayR3/data-transfer.md
@@ -7,7 +7,7 @@ MidwayR3 has no connection to the internet and can only be accessed by logging i
 
 ### Method #1 (recommended) : Transferring Using UChicago Box from within the SDE Desktop 		
 
-Once you logged in to the MidwayR3 desktop (see [Connecting to the SDE Desktop](../connecting/index.md)), you can open a browser and log in to a Box account at [https://uchicago.account.box.com](https://uchicago.account.box.com/login):<br><br>
+Once you logged in to the MidwayR3 desktop (see [Connecting to the SDE Desktop](connecting.md)), you can open a browser and log in to a Box account at [https://uchicago.account.box.com](https://uchicago.account.box.com/login):<br><br>
 ![screenshot showing VMware Horizon data transfer](images/box_login.jpg)
 <br><br>
 

--- a/docs/tutorials/kicp_tutorial.md
+++ b/docs/tutorials/kicp_tutorial.md
@@ -1,0 +1,662 @@
+# KICP Tutorial
+
+!!! Note
+    This page was migrated from the previous User Guide with minor editing. Some details may now be deprecated. See the main sections of this guide for the most up-to-date content. 
+
+The KICP has exclusive access to a number of compute nodes associated with the RCC
+Midway cluster.  KICP users access those nodes through the same login nodes and
+interfaces as the primary cluster, making it trivial to move computational work
+between the two sets of resources. Most of the documentation available on this site is applicable to KICP members and the KICP nodes, however there are some specific differences which are described here.
+
+Email sent to [kicp@rcc.uchicago.edu](mailto:kicp@rcc.uchicago.edu) will be assigned a trouble ticket and reviewed
+by the RCC Help Desk.  Please don’t hesitate to ask questions if
+you encounter any issues, or have any requests for software installation.
+
+## Get an account
+
+Please complete the RCC [User Account Request](https://rcc.uchicago.edu/general-user-account-request) form to request an account and put KICP as
+the PI (note: this request will be reviewed for KICP membership).  Please clearly state your
+connection to the KICP, particularly if you are not a local or senior member.  If you are
+requesting access for someone not at the University of Chicago (i.e. someone who doesn’t have
+a CNetID), the account creation process will involve creating a CNetID.
+
+To access the rest of the Midway cluster you will need to be added to a different account
+than KICP, typically provided by a faculty member acting as PI. All KICP faculty are eligible
+to act as PI for themselves and others, and many already have PI accounts on the Midway cluster.
+
+## Submit A Job
+
+As a shared resource, Midway uses a batch queueing system to allocate nodes to individuals
+and their jobs.  Midway uses the [Slurm](http://slurm.schedmd.com) batch queuing system, which is similar to the possibly
+more familiar PBS batch system.
+
+Please see the Midway2 and Midway3 HPC Systems section of this User Guide for information on using Midway to perform
+computational tasks, typically by submitting batch jobs. The [Slurm](http://slurm.schedmd.com) commands, reiterated below,
+can be used as described in that documentation, however KICP users may need to point to one of the
+two KICP partitions, kicp and kicp-ht, and select the kicp account.
+
+**NOTE**: Specifying –account=kicp and –partition=kicp is generally optional for users who belong to
+the KICP group and no other, however specifying them is generally good practice.
+
+| Useful Commands        | Description                                                   |
+|------------------------|---------------------------------------------------------------|
+| sbatch -p kicp -a kicp | Submit a job to the Slurm scheduling system.                  |
+| sinteractive -p kicp   | Run an interactive job on a KICP compute node                 |
+| squeue -p kicp         | List the submitted and running jobs in the KICP partition.    |
+| squeue -u $USER        | List the current users’ own submitted and running jobs.       |
+| sinfo -p kicp          | List the number of available and allocated KICP nodes.        |
+| scancel job_id         | Cancel the job identified by the given job_id (e.g. 3636950). |
+| scancel -u $USER       | Cancel all jobs submitted by the current user                 |
+
+
+There are many ways to submit a batch job, depending on what that job requires (number of
+processors, number of nodes, etc). Slurm will automatically start your job in the directory
+from which it was submitted.  To submit a job, create a batch script, say my_job.sh and submit
+with the command sbatch my_job.sh.  The following is a list of commonly used sbatch commands.  A
+more complete list can be found in the sbatch man page.
+
+The following is a good example batch script:
+
+```default
+#!/bin/bash
+
+#SBATCH --job-name=my_job
+#SBATCH --output=my_job_%j.out
+#SBATCH --time=24:00:00
+#SBATCH --partition=kicp
+#SBATCH --account=kicp
+#SBATCH --nodes=1
+#SBATCH --exclusive
+
+echo $SLURM_JOB_ID starting execution `date` on `hostname`
+
+# load required modules (change to your requirements!)
+# example: module load openmpi/1.8
+
+# uncomment below if your code uses OpenMP to properly set the number of threads
+# export OMP_NUM_THREADS=$SLURM_CPUS_PER_TASK
+
+# the commands to run your job
+# example: mpirun ./my_task
+# Note: slurm will automatically tell MPI how many tasks and tasks per node to use
+```
+
+### KICP Queues
+
+KICP has the access to the following queues (partition in Slurm terminology):
+
+| Partition | Wallclock limit | Job limits                     |
+|-----------|-----------------|--------------------------------|
+| kicp      | 48h             | 256 cores, 64 jobs per user    |
+| kicp-ht   | 36h             | 64 cores/job, 32 jobs per user |
+| kicp-long | 100h            | 128 cores/queue, 64 cores/user |
+
+
+access to kicp-long requires special authorization.
+
+If you are running jobs with significant I/O or communication between nodes (typically MPI jobs),
+then you should use the the tightly-coupled, infiniband nodes accessed through the kicp and kicp-long
+partitions. Purely serial or embarrassingly parallel jobs with a large calculation to I/O ratio (say MCMC
+likelihood sampling) should use the high-throughput nodes in the kicp-ht queue.  The limits for kicp-ht
+were relaxed to encourage use.  If users start to conflict, they may be restricted to prevent
+a single user from dominating those nodes.
+
+Midway also includes two large memory (256GB) and four GPU enabled nodes, as well as a significantly larger
+set of nodes that are shared with the rest of the University.  Accessing these resources requires a separate
+allocation.  Please contact the RCC for more details.
+
+## Storage
+
+Your home directory has a 30G quota,
+and should be used for small files and codes.
+
+KICP has a 50TB allocation in `/project/kicp/`, and each user is initially given a 1TB quota and their
+own subdirectory (`/project/kicp/$USER)`. If you require more space, please let the RCC know and
+your quota may be increased on a case-by-case basis.
+
+New project space is no longer allocated under /project but under /project2.
+
+Both home and project space are backed up hourly
+to disk, and daily to tape.
+
+Finally, there is a high-performance filesystem mounted on /scratch/midway2 which should be used during runs and
+has a 5TB quota. This
+directory is not backed up and should not be used for long-term storage. In future, files older than a to be
+determined age may be removed automatically, so please practice good data management.
+
+### Snapshots and Backups
+
+We all inadvertently delete or overwrite files from time to time.  Snapshots are automated backups that
+are accessible through a separate path.  Snapshots of a user’s home directory can be found in
+`/snapshots/\*/home/*cnetid*/` where the subdirectories refer to the frequency and time of
+the backup, e.g. daily-2012-10-04.06h15 or hourly-2012-10-09.11h00.
+
+## Software
+
+Many common astrophysical codes and libraries have been installed or built on Midway. Other common astrophysics packages require configuration at compilation that prevent them from being installed system-side. Look here for program specific compilation flags, installation instructions, etc for these packages.
+Please contact the RCC if you notice any problems with any of the software or instructions.
+
+### IDL
+
+IDL is installed on Midway, however the RCC is unable to provide licenses to the entire community. Users who have their own licenses or license servers may configure them to be able to use IDL on Midway’s login and compute nodes. Contact RCC for more details.
+
+### CosmoMC
+
+CosmoMC is a Markov-Chain Monte-Carlo (MCMC) code which is integrated with the theoretical power spectrum code CAMB.  Since
+it is often modified by users, we don’t install a system-wide version, however we have verified that the following parameters
+give good performance (Warning: under construction, don’t use these instructions without first talking to the RCC).
+
+Specific installation instructions for a non-mpi build using the intel compiler and the intel math kernel library mkl 10.3
+(note, these differ slightly from those provided by the CosmoMC readme ):
+
+* Download CosmoMC from cosmologist.info and untar on Midway
+
+
+* Load the modules appropriate for the compiler you intend to use.  In this case a non-mpi build with the intel compiler: `module load intel/12.1 cfitsio/3+intel-12.1 mkl/10.3`
+
+
+* Edit the CosmoMC Makefile located in the source subdirectory
+
+The WMAP7 likelihood code and data are already configured and installed on Midway in the `/project/kicp/opt/WMAP/` directory.
+The stock v4 and v4p1 versions from Lambda  are installed, as is a patched version of v4 with special optimizations from
+Cora Dvorkin & Wayne Hu.  Select the version you wish to use and change the WMAP variable to point to the full directory, e.g.
+`WMAP = /project/kicp/opt/WMAP/likelihood_v4p1`.
+
+
+* Modify the compiler and optimization options
+
+```bash
+F90C = ifort
+FFLAGS = -O2 -openmp -fpp
+LAPACKL = $(MKLROOT)/lib/intel64/libmkl_lapack95_lp64.a \
+              -Wl,--start-group \
+              $(MKLROOT)/lib/intel64/libmkl_intel_lp64.a \
+              $(MKLROOT)/lib/intel64/libmkl_sequential.a \
+              $(MKLROOT)/lib/intel64/libmkl_core.a \
+              -Wl,--end-group -lpthread
+```
+
+
+* Run make
+
+Note, this section is under construction.  Updated build instructions for a variety of compilers and mpi support will come soon.
+
+### ART
+
+ART has default compilation flags for Midway.  Set the environment variable PLATFORM to midway. This platform file will automatically detect
+the MPI environment and compiler option you are using and configure the code accordinly.
+
+### RAMSES
+
+Ramses is a cosmological hydrodynamic adaptive mesh refinement code originally written by Romain Teyssier.  It is public, and can be
+downloaded .  Oscar Agertz has compiled and run Ramses on Midway and reports good performance with the following makefile configuration:
+
+```bash
+F90 = mpif90 -O3
+FFLAGS = -cpp -DNVAR=$(NVAR) -DNDIM=$(NDIM) -DNPRE=$(NPRE) \
+            -DSOLVER$(SOLVER) -DNOSYSTEM -DNVECTOR=$(NVECTOR)
+LIBMPI =
+LIBS = $(LIBMPI)
+```
+
+### Gadget
+
+This refers to the public version of Gadget 2.0.7. The following Makefile configuration should work under all combination of compilers, MPI libraries, and Gadget options (including HDF5 support):
+
+```bash
+CC = mpicc
+OPTIMIZE = -O3
+MPICHLIB =
+HDF5INCL = -DH5_USE_16_API
+HDF5LIB = -lhdf5
+```
+
+The code requires that modules are loaded for fftw2, gsl, mpi, and an optional hdf5.  Make sure to load compiler and MPI library specific versions of the modules as necessary.  Some examples are given below:
+
+
+* Intel compiler + Intel MPI (note, loading intelmpi will automatically load intel/12.1):
+
+```bash
+module load intelmpi/4.0+intel-12.1 fftw2/2.1.5+intelmpi-4.0+intel-12.1 hdf5/1.8 gsl/1.15
+```
+
+
+* Intel compiler + OpenMPI:
+
+```bash
+module load openmpi/1.6+intel-12.1 fftw2/2.1.5+openmpi-1.6+intel-12.1 hdf5/1.8 gsl/1.15
+```
+
+
+* GCC + OpenMPI:
+
+```bash
+module load openmpi/1.6 fftw2/2.1.5+openmpi-1.6 hdf5/1.8 gsl/1.15
+```
+
+
+
+
+## Automating Large Numbers of Tasks
+
+Researchers often need to perform a number of calculations
+that vary only in their initial conditions or input parameters.
+Such tasks naturally arise when exploring the predictions of a
+model over a range of parameters or when testing a numerical
+calculation for convergence. Automating these tasks is critical,
+both for computational efficiency and to minimize human error and
+ensure the calculation is reproducible.
+
+This tutorial will discuss a number of techniques and tools
+available on Midway for automating the running of tasks and
+their respective advantages and disadvantages. In particular
+we will focus on those tasks which are entirely
+independent of each other and where the total number of tasks
+is known (and fixed).
+
+When deciding between the various techniques, users should
+consider the following:
+
+* overhead or cost of starting each task (including cost of starting remote processes)
+* waiting time each batch job will spend in the queue
+* total number of jobs compared to available resources and limits
+* the average calculation time per job and its variance
+* the cost in developer time needed for a given solution
+
+As a semi-realistic example, this tutorial will use the CLASS
+code to compute the non-linear matter power specturm for a range
+of the neutrino parameter N_eff.
+
+### CLASS and classy
+
+[CLASS](http://class-code.net/) [[1104.2932](http://arxiv.org/abs/1104.2932)] is a Boltzmann code similar
+to CMBFAST, CAMB, and others. It can be used to compute a number of large-scale
+structure and CMB observables and since it is designed to perform calculations
+within MCMC-type likelihood analyses, it is a good option for these exercises.
+
+To install **CLASS** and its Python wrapper, **classy**, use the
+following commands:
+
+```bash
+module load git python/2.7-2014q3
+git clone https://github.com/lesgourg/class_public
+cd class_public
+make
+```
+
+**NOTE**: This will install the Class python wrappers in your .local directory
+while remembering where you compiled CLASS. Make sure you delete them
+both after completing the exercises.
+
+[classy](https://github.com/lesgourg/class_public/wiki/Python-wrapper)
+is a Python wrapper for the CLASS code which we will use for convenience.
+It allows us to avoid the common issue of dealing with parameter files
+
+The code that uses classy to compute the non-linear matter power spectrum
+for a given N_eff is as follows:
+
+```python
+#!/bin/env python
+
+def compute_pk(N_eff=3.04, output="pk.dat"):
+    import numpy as np
+    from classy import Class
+
+    # initialize Class with default parameters save N_eff
+    c = Class()
+    c.set({'output':'mPk', 'non linear':'halofit', 'N_eff':N_eff})
+    c.compute()
+    with open(output, "w") as output:
+        for k in np.logspace(-3., 0.5, 100):
+            print >>output, "%.6e %.6e" % (k, c.pk(k, z=0.0))
+    c.struct_cleanup()
+
+    # if necesssary for visualization, add a 5 second delay
+    #import time; time.sleep(5)
+
+# perform work associated with i out of N steps
+def work(i, N=100):
+    N_eff_min = 2.5
+    N_eff_max = 4.5
+    N_eff = (N_eff_max-N_eff_min)*float(i)/float(N) + N_eff_min
+    output = "pk_{}.dat".format(i)
+    compute_pk(N_eff, output)
+
+# collect the resulting matter power spectra and plot 
+def plot_pk(file_pattern="pk_*.dat",output="pk.png"):
+    import pylab, glob
+    import numpy as np
+
+    f = pylab.figure(figsize=(5,5))
+    for data in glob.glob(file_pattern):
+        (k, pk) = np.loadtxt(data, unpack=True)
+        f.gca().loglog(k, pk, color='k', alpha=0.05)
+    f.gca().set_xlabel("k [Mpc/h]")
+    f.gca().set_ylabel("P(k)")
+    f.tight_layout()
+    f.savefig(output)
+
+if __name__ == "__main__":
+    import sys
+    if len(sys.argv) == 3:
+        work(int(sys.argv[1]), int(sys.argv[2]))
+    else:
+        plot_pk()
+
+    print "done"
+```
+
+Run this code without any input parameters to generate the following png figure
+from the resulting output files.
+
+
+#### Parallel Programming
+
+Implementing your own parallel scheme is useful when the tasks are not completely
+independent, or represent only a part of a larger, non-trivial workflow. Calculations
+that rely on large pre-calculated tables or have costly initilization may also benefit
+from an explicit scheme, as those costs can be amortized over a larger number of tasks.
+
+### Multiprocessing
+
+Smaller numbers of tasks can be divided amongst workers on a single node. In high
+level languages like Python, or in lower level languages using threading language
+constructs such as OpenMP, this can be accomplished with little more effort than a
+serial loop. This example also demonstrates using Python as the script interpreter
+for a Slurm batch script, however note that since Slurm copies and executes batch
+scripts from a private directory, it is necessary to manually add the runtime
+directory to the Python search path.
+
+```python
+#!/bin/env python
+
+#SBATCH --job-name=multiprocess
+#SBATCH --output=logs/multiprocess_%j.out
+#SBATCH --time=01:00:00
+#SBATCH --partition=kicp
+#SBATCH --account=kicp
+#SBATCH --nodes=1
+#SBATCH --exclusive
+
+import multiprocessing
+import sys
+import os
+
+# necessary to add cwd to path when script run 
+# by slurm (since it executes a copy)
+sys.path.append(os.getcwd()) 
+from pk import work
+
+# get number of cpus available to job
+try:
+    ncpus = int(os.environ["SLURM_JOB_CPUS_PER_NODE"])
+except KeyError:
+    ncpus = multiprocessing.cpu_count()
+
+# create pool of ncpus workers
+p = multiprocessing.Pool(ncpus)
+
+# apply work function in parallel
+p.map(work, range(100))
+```
+
+### MPI
+
+Process and threaded level parallelism is limited to a single machine. To
+
+```python
+#!/bin/env python
+
+#SBATCH --job-name=mpi
+#SBATCH --output=logs/mpi_%j.out
+#SBATCH --time=01:00:00
+#SBATCH --partition=kicp
+#SBATCH --ntasks=100
+
+from mpi4py import MPI
+from pk import work
+
+comm = MPI.COMM_WORLD
+rank = comm.Get_rank()
+size = comm.Get_size()
+
+work(rank, size)
+```
+
+MPI programs and Python scripts must be launched using **mpirun** as shown
+in this Slurm batch script:
+
+```bash
+#!/bin/bash
+
+#SBATCH --job-name=mpi
+#SBATCH --output=logs/mpi_%j.out
+#SBATCH --time=01:00:00
+#SBATCH --partition=kicp
+#SBATCH --account=kicp
+#SBATCH --ntasks=100
+
+module load mpi4py/1.3-2014q3+intelmpi-4.0
+
+mpirun python mpi_pk.py
+```
+
+In this case we are only using MPI as a mechanism to remotely launch tasks on distributed
+nodes. All processes must start and end at the same time, which can lead to waste
+of resources if some job steps take longer than others.
+
+#### Job Scheduler
+
+Most of this workshop will focus on using various features of Midway’s batch scheduler,
+[Slurm](http://slurm.schedmd.com) as it’s sole purpose is to help organize  organize
+
+### Slurm task per job
+
+In some cases it may be easiest to wrap the job submission in a
+script or bash command, taking advantage of the fact that Slurm
+will pass on environment variables defined at the time of job
+submission (this is also why you can load modules before submitting
+a job rather than inside the job script itself).
+
+```bash
+for i in {0..10}; do export i; sbatch job.sbatch; done
+```
+
+```bash
+#!/bin/bash
+
+#SBATCH --job-name=job
+#SBATCH --output=logs/job_%j.out
+#SBATCH --time=01:00:00
+#SBATCH --partition=kicp
+#SBATCH --account=kicp
+#SBATCH --ntasks=1
+
+python pk.py $i 100
+```
+
+**NOTE**: It can be difficult to monitor and jobs submitted in this way. Be sure to use a unique
+job-name so you can identify a particular job group with commands like squeue and scancel,
+e.g. `scancel -n class`
+
+### GNU Parallel
+
+[GNU Parallel](http://www.gnu.org/software/parallel/) is a tool for executing tasks in parallel, typically on a single machine. When
+coupled with the [Slurm](http://slurm.schedmd.com) command **srun**, **parallel** becomes a powerful way
+of distributing a set of tasks amongst a number of workers. This is particularly useful when
+the number of tasks is significantly larger than the number of available workers (Slurm’s
+`--ntasks`).
+
+```bash
+#!/bin/sh
+
+#SBATCH --time=01:00:00
+#SBATCH --output=logs/parallel.log
+#SBATCH --partition=kicp
+#SBATCH --account=kicp
+#SBATCH --ntasks=32
+#SBATCH --exclusive
+
+module load parallel
+
+# the --exclusive to srun makes srun use distinct CPUs for each job step
+# -N1 -n1 allocates a single core to each task
+srun="srun --exclusive -N1 -n1"
+
+# --delay .2 prevents overloading the controlling node
+# -j is the number of tasks parallel runs so we set it to $SLURM_NTASKS
+# --joblog makes parallel create a log of tasks that it has already run
+# --resume makes parallel use the joblog to resume from where it has left off
+# the combination of --joblog and --resume allow jobs to be resubmitted if
+# necessary and continue from where they left off
+parallel="parallel --delay .2 -j $SLURM_NTASKS --joblog logs/runtask.log --resume"
+
+# this runs the parallel command we want
+# in this case, we are running a script named runtask
+# parallel uses ::: to separate options. Here {0..99} is a shell expansion
+# so parallel will run the command passing the numbers 0 through 99
+# via argument {1}
+$parallel "$srun python pk.py {1} 100 > logs/parallel_{1}.log" ::: {0..99}
+
+```
+
+This job is submitted as with any [Slurm](http://slurm.schedmd.com) batch job
+
+```bash
+$ sbatch parallel.sbatch
+```
+
+and will appear as a single job in the queue, assigned as many nodes/cores as was requested:
+
+```bash
+$ squeue -u $USER -p kicp
+   JOBID PARTITION     NAME     USER ST       TIME  NODES NODELIST(REASON)
+11511073      kicp parallel    drudd  R       0:00      2 midway[203,390]
+```
+
+GNU Parallel maintains a log of the work that has already been done, along with the exit
+value of each step (useful for determining any failed steps).
+
+```bash
+$ head logs/runtask.log
+Seq Host    Starttime   Runtime Send    Receive Exitval Signal  Command
+1   :   1422211597.529  6.467   0   0   0   0   srun --exclusive -N1 -n1 python pk.py 0 100 > logs/runtask.0
+2   :   1422211597.732  6.466   0   0   0   0   srun --exclusive -N1 -n1 python pk.py 1 100 > logs/runtask.1
+3   :   1422211597.935  6.466   0   0   0   0   srun --exclusive -N1 -n1 python pk.py 2 100 > logs/runtask.2
+4   :   1422211598.138  6.464   0   0   0   0   srun --exclusive -N1 -n1 python pk.py 3 100 > logs/runtask.3
+```
+
+In our case we requested the output from each work step be directed to a file **logs/runtask.{1}**,
+allowing us to peform further diagnostics if necessary. The parallel option `--resume` creates a file
+**parallel.log** which allows GNU Parallel to resume a job that has been stopped due to failure or by hitting
+a walltime limit before all tasks have been completed. If you need to rerun a GNU Parallel job, be sure
+to delete **parallel.log** or it will think it has already finished!
+
+**NOTE**: More information may found in the RCC documentation section [Parallel batch jobs](,../midway23/examples/example_job_scripts.md).
+
+### Slurm Job array
+
+Most HPC job schedulers support a special class of batch job known as array jobs (or job arrays).
+[Slurm](http://slurm.schedmd.com) support for job arrays is relatively new and is undergoing active development. The GNU Parallel
+solution in the previous section was developed at RCC because of the former lack of [Slurm](http://slurm.schedmd.com) array
+jobs.
+
+An example [Slurm](http://slurm.schedmd.com) array job submission script is as follows:
+
+```bash
+#!/bin/bash
+
+#SBATCH --job-name=array
+#SBATCH --output=logs/array_%A_%a.out
+#SBATCH --array=0-99
+#SBATCH --time=01:00:00
+#SBATCH --partition=kicp
+#SBATCH --account=kicp
+#SBATCH --ntasks=1
+
+# the environment variable SLURM_ARRAY_TASK_ID contains
+# the index corresponding to the current job step
+python pk.py $SLURM_ARRAY_TASK_ID 100
+```
+
+This looks very similar to our single-job batch submission script, but with the addition
+of the `--array` feature. In this case, the `--array=0-99` will cause 100
+individual array-tasks to be created when this job script is submitted. Each array task
+is a copy of the master script, with an environment variable called `SLURM_ARRAY_TASK_ID`
+set to the index of the array task. As with the GNU Parallel example, we simply pass the
+value of that environment variable into our program to perform that piece of work.
+
+Each array job will enter the queue and run when resources are available for it, as if we had
+submitted each job manually (this is merely a highly-convenient shortcut).
+
+Array job indices do not need to be a linear range, and can be specified in a number of ways.  For example:
+
+```default
+A job array with index values of 1, 2, 5, 19, 27:
+#SBATCH --array=1,2,5,19,27
+
+A job array with index values between 1 and 7 with a step size of 2 (i.e. 1, 3, 5, 7):
+#SBATCH --array=1-7:2
+```
+
+The `%A_%a` construct in the output and error file names is used to generate unique output and error files
+based on the master job ID (%A) and the array-tasks ID (%a).  In this fashion, each array-tasks will be able to
+write to its own output and error file.
+
+When we submit a job array, we will see the master process, as well as any submitted, running or otherwise
+not completed array tasks with the naming convention `%A_%a`.
+
+```bash
+$ squeue
+           JOBID PARTITION     NAME     USER ST       TIME  NODES NODELIST(REASON)
+11510950_[10-99]      kicp    array    drudd PD       0:00      1 (None)
+      11510950_0      kicp    array    drudd  R       0:00      1 midway185
+      11510950_1      kicp    array    drudd  R       0:00      1 midway185
+      11510950_2      kicp    array    drudd  R       0:00      1 midway185
+      11510950_3      kicp    array    drudd  R       0:00      1 midway185
+      11510950_4      kicp    array    drudd  R       0:00      1 midway185
+      11510950_5      kicp    array    drudd  R       0:00      1 midway185
+      11510950_6      kicp    array    drudd  R       0:00      1 midway185
+      11510950_7      kicp    array    drudd  R       0:00      1 midway185
+      11510950_8      kicp    array    drudd  R       0:00      1 midway185
+      11510950_9      kicp    array    drudd  R       0:00      1 midway185
+```
+
+We can cancel all array tasks associated with the master job ID as before, or cancel any subset of them using
+the naming convention `%A_%a`
+
+```bash
+# cancel job steps 10-100
+$ scancel 11510950_[10-100]
+
+# cancel all remaining job steps
+$ scancel 11510950
+```
+
+What happens if we try to submit a job with, say, `--array=0-1000`?
+
+```bash
+sbatch: error: Batch job submission failed: Job violates accounting/QOS policy (job submit limit, user's size and/or time limits)
+```
+
+The number of jobs a user may have submitted (not running!) at any given time is limited, in order to
+avoid overloading the scheduler and to ensure users cannot accidentally swamp the machines with malformed
+job submissions. To see how many jobs can be run or submitted for a given partition+QOS, use the following
+command:
+
+```bash
+$ sacctmgr list qos kicp format=maxjobsperuser, maxsubmitjobsperuser
+MaxJobsPU MaxSubmitPU
+--------- -----------
+       64         128
+```
+
+The ability to submit array jobs which are larger than `MaxSubmitPU` is coming in a newer
+version of [Slurm](http://slurm.schedmd.com). Until then, each job should handle more than one piece of work, or the GNU Parallel
+solution should be used. For more information, see the RCC documentation section [Job arrays](../../running-jobs/array/index.md#array-jobs).
+
+#### Workflow Tools
+
+Other specialized tools have been created for handling parallel workflows, particularly in specific
+domains or for specific analysis or computational codes. Developing such tools is an open area of
+research.

--- a/docs/tutorials/kicp_tutorial.md
+++ b/docs/tutorials/kicp_tutorial.md
@@ -1,7 +1,7 @@
 # KICP Tutorial
 
 !!! Note
-    This page was migrated from the previous User Guide with minor editing. Some details may now be deprecated. See the main sections of this guide for the most up-to-date content. 
+    This page was migrated from the previous user guide with minimal editing. Some details may now be out of date. See the main sections of this guide for the most up-to-date content. 
 
 The KICP has exclusive access to a number of compute nodes associated with the RCC
 Midway cluster.  KICP users access those nodes through the same login nodes and

--- a/docs/tutorials/msca_tutorial.md
+++ b/docs/tutorials/msca_tutorial.md
@@ -1,0 +1,188 @@
+# Introduction to RCC for MSc in Analytics
+
+As a student in the Master of Science in Analytics (MScA) Program, you will be able to make use of The University of Chicago’s Research Computing Center (RCC) resources in completing your capstone project.  Some courses in the program will also make use of RCC resources.
+
+RCC provides high-end research computing resources to researchers at the University of Chicago. These resources include centrally managed high-performance computing, storage, and visualization hardware, software, scientific and technical user support, as well as education and training opportunities to help researchers effectively make use of modern HPC technology.  To learn more about RCC, see [https://rcc.uchicago.edu](https://rcc.uchicago.edu).
+
+Below are the basics you will need to know in order to get up and running at RCC.  For complete RCC technical documentation, see the main sections of this user guide. 
+
+## Getting Help
+
+RCC support staff is available to assist with technical issues (help logging in, questions about using the cluster, etc).  Please don’t hesitate to ask questions if you encounter any technical issues.
+
+
+* The preferred way of requesting support is to send an email request to [help@rcc.uchicago.edu](mailto:help@rcc.uchicago.edu)
+
+
+* RCC’s walk-in lab is open during business hours and is located in Regenstein Library room 216. Feel free to drop by to chat with one of our staff members if you get stuck.
+
+
+* The RCC helpdesk can be also reached by phone at 773-795-2667 during normal business hours.
+
+## Logging into Midway
+
+For the most complete documentation regarding connecting to RCC resources see: [Connecting to RCC Resources](../../connecting/index.md#connecting).
+
+### Credentials
+
+All users must have a UChicago [CNetID](https://itservices.uchicago.edu/services/cnetid) to log in to any RCC system. Your RCC account uses the same username/password as your CNetID:
+
+```default
+Username: CNetID
+Password: CNet password
+```
+
+Upon acceptance into the MScA program, a RCC user account will automatically be activated for you.  If all has gone according to plan, there is no action required to obtain an RCC user account.  However, if for whatever reason you believe your account has not been activated, please contact [help@rcc.uchicago.edu](mailto:help@rcc.uchicago.edu)
+
+**NOTE**: RCC does not store your CNet password and we are unable to reset your password.
+If you require password assistance, please see the [CNet Password Recovery](https://cnet.uchicago.edu/recertify/) webpage.
+
+### 2-Factor Authentication
+
+Follow the instructions on [https://2fa.rcc.uchicago.edu](https://2fa.rcc.uchicago.edu) to enroll into 2fa.
+
+### Connecting with SSH
+
+Access to RCC resources is provided via secure shell (SSH) login.  Most Unix-like operating systems (Mac OS X, Linux, etc) provide an ssh utility by default that can be accessed by typing the command **ssh** in a terminal window.
+
+To login to midway2 from a Linux or Mac computer, open a terminal and at the command line enter:
+
+```default
+$ ssh <CNetID>@midway2.rcc.uchicago.edu
+```
+
+Windows users will first need to download an ssh client, such as [PuTTY](http://www.chiark.greenend.org.uk/~sgtatham/putty/) or 
+
+```
+MobaXterm_
+```
+
+, which will allow you to interact with the remote Unix command line. Use the following information to set up your connection:
+
+```default
+Hostname: midway2.rcc.uchicago.edu
+Username: CNetID
+Password: CNet password
+```
+
+### Connecting with ThinLinc
+
+ThinLinc is a remote desktop server that can be used to connect to RCC systems and obtain a remote graphical user interface (GUI). RCC recommends that ThinLinc be used when running software that requires a GUI.
+
+**NOTE**: You can connect to RCC systems via the ThinLinc web client at [https://midway2.rcc.uchicago.edu](https://midway2.rcc.uchicago.edu). The performance will be slower, but no client download is necessary.
+
+There are some differences between the Mac OS X, Windows, and Linux clients, but for the most part, these steps should be followed:
+
+
+* Download and install the appropriate ThinLinc client here:
+[https://www.cendio.com/thinlinc/download](https://www.cendio.com/thinlinc/download)
+
+
+* Open the ThinLinc client and use the following information to set up your connection:
+
+```default
+Server: midway2.rcc.uchicago.edu
+Username: CNetID
+Password: CNet password
+```
+
+Your client should look similar to this:
+
+
+
+![image](./img/thinlinc-client.png)
+
+
+* The default setting for ThinLinc is for the client to open in a fullscreen window that fills “all monitors.” If you would prefer to work with ThinLinc from its own window, click *Options* from the initial login interface and then *Screen* to adjust your settings as desired. The following is an example of a setup that places the ThinLinc client in its own window:
+
+
+
+![image](./img/thinlinc-options.png)
+
+
+* *Optional*: You are also able to export local resources via ThinLinc. To do so, click *Options* from the initial login interface and then *Local Devices*. To adjust your settings for exporting the local file system, click *Details* next to *Drives*.
+
+
+
+![image](./img/thinlinc-local-resources.png)
+
+
+* Upon successfully logging in, you will be presented with an gnome desktop.
+Click with right mouse button anywhere on the desktop and select “Open Terminal” from the menu.
+
+
+
+![image](./img/thinlinc-desktop.png)
+
+With ThinLinc it is possible to maintain an active session after you have closed your connection to Midway.  To disconned from Midway but maintain an active session (e.g. when you log back into the ThinLinc client you will resume your remote session from where you left off), simply close the ThinLinc window. NOTE: You must have *End existing session* **unchecked** for this to occur.
+
+To exit ThinLinc and terminate your session completely, simply select *Logout* from the *Applications* menu.
+
+## Using the Midway Cluster
+
+The Midway compute cluster is a shared resource used by the entire University community. Sharing computational resources creates unique challenges:
+
+
+* Jobs must be scheduled in a fair manner.
+
+
+* Resource consumption needs to be accounted.
+
+
+* Access needs to be controlled.
+
+Thus, a **scheduler** is used to manage job submissions to the cluster.  RCC uses the [Slurm](http://slurm.schedmd.com) resource manager to schedule jobs and provide interactive access to compute nodes.
+
+For detailed information on running specific types of compute jobs, consult the pages [Using Midway](../../using-midway/index.md#using-midway) and [Running jobs on midway](../../running-jobs/index.md#running-jobs).  Software-specific information can be found on the RCC [Software](../../software/index.md#software) page.
+
+## Data Transfer, Storage, and Backup
+
+RCC maintains a petascale high-performance GPFS shared file system which is used for users’ home directories, shared project space, and high-throughput scratch space.
+
+### Transferring files
+
+RCC provides a number of methods for accessing and transferring data in/out of our systems. We recommend the scp protocol for transferring files to/from RCC systems. RCC hosts a managed Globus Online endpoint that can be used for moving very large amounts of data. When connecting from the UChicago network or through the UChicago VPN it is also possible to connect to the RCC file systems using SAMBA.
+
+Please see the [Data Transfer](../../data-transfer/index.md#data-transfer) page for more information on how to move files to/from Midway.
+
+### Persistent and Temporary Storage
+
+You will have access to three different storage locations on Midway.
+
+All users are given a home directory with a 30GB quota.  This location should be used for small files, code, etc.  It is located at `/home/$USER`.
+
+For large capacity storage, MScA has obtained a block of high-capacity storage located at `/project/msca/`.  Each MScA user is initially given a 10GB quota on their own subdirectory (`/project/msca/$USER)`.  If you require more space, please contact Gregory Guevara <[gguevara@uchicago.edu](mailto:gguevara@uchicago.edu)> with a description of your requirements and an estimate of how much storage you will require.  Storage quotas in `/project/msca` will be increased on a case-by-case basis and may require a monetary contribution by the user.
+
+Finally, you will have access to a high-performance filesystem mounted on `/scratch/midway2/$USER` which has a 100GB quota. This storage location is intended for SHORT-TERM STORAGE ONLY.
+
+**NOTE**: Your scratch directory is NOT backed up and should NOT be used for long-term storage. Files stored in your scratch space that are older than 2 weeks may be removed automatically, so please practice good data management.
+
+### Backups and Snapshots
+
+We all inadvertently delete or overwrite files from time to time.  Snapshots are automated backups that are accessible through a separate path.  Snapshots of a user’s home directory can be found in `/snapshots/\*/home/$USER/` where the subdirectories refer to the frequency and time of the backup, e.g. daily-2012-10-04.06h15 or hourly-2012-10-09.11h00.  More information about backups can be found in the [Snapshots](../../data-storage/index.md#snapshots) section of the [Data Storage](../../data-storage/index.md#data-storage) page.
+
+While snapshots are the preferred way to recover lost files, RCC also maintains an archival tape backup of data stored in `/project` and `/home` file systems for disaster recovery purposes only.
+
+## Software
+
+Many commonly used software packages and libraries have been installed on Midway for your use.  See the complete [Software Module List](../../software/modules/index.md#modules) for a list of all software installed on Midway.  For an overview of how to use Software Modules on Midway, consult the RCC [Software](../../software/index.md#software) documentation page.
+
+## SAS
+
+SAS Studio is available to MScA students. SAS Studio is a web application
+frontend to SAS. To access SAS Studio, visit this link and log in with your
+CNetID and password:
+
+[https://sas-studio.rcc.uchicago.edu](https://sas-studio.rcc.uchicago.edu)
+
+Also, an instance of SAS Enterprise Miner is available to MScA students.  To access SAS Enterprise Miner, you can visit this link:
+
+[https://sas-miner.rcc.uchicago.edu:8343/SASEnterpriseMinerJWS/Status](https://sas-miner.rcc.uchicago.edu:8343/SASEnterpriseMinerJWS/Status)
+
+SAS software is also available on Midway.  To load the SAS software module, use the command `module load sas`. It is recommended to use ThinLinc as described above to login to Midway if you want to use SAS in this manner.
+
+## Nielsen Data
+
+The MScA program has obtained a subset of the Nielsen Homescan data for use in teaching and research projects.  Access to this data is controlled by MScA administration.  If you require access to this data, please consult your instructor or the MScA director and request that you be approved for access to the data.
+
+Once your user account has been approved for access to the Nielsen data, you will be able to access the data in the directory `/project/msca/data/nielsen/` on Midway.

--- a/docs/tutorials/msca_tutorial.md
+++ b/docs/tutorials/msca_tutorial.md
@@ -11,161 +11,22 @@ Below are the basics you will need to know in order to get up and running at RCC
 RCC support staff is available to assist with technical issues (help logging in, questions about using the cluster, etc).  Please don’t hesitate to ask questions if you encounter any technical issues.
 
 
-* The preferred way of requesting support is to send an email request to [help@rcc.uchicago.edu](mailto:help@rcc.uchicago.edu)
+* The preferred way of requesting support is to [contact our Help Desk](https://rcc.uchicago.edu/support-and-services/consulting-and-technical-support){:target="_blank"}.
 
 
 * RCC’s walk-in lab is open during business hours and is located in Regenstein Library room 216. Feel free to drop by to chat with one of our staff members if you get stuck.
 
-
-* The RCC helpdesk can be also reached by phone at 773-795-2667 during normal business hours.
-
 ## Logging into Midway
 
-For the most complete documentation regarding connecting to RCC resources see: [Connecting to RCC Resources](../../connecting/index.md#connecting).
+For the most complete documentation regarding connecting to RCC resources see: [Connecting to Midway](../midway23/midway_connecting.md).
 
-### Credentials
+## Using Midway
 
-All users must have a UChicago [CNetID](https://itservices.uchicago.edu/services/cnetid) to log in to any RCC system. Your RCC account uses the same username/password as your CNetID:
-
-```default
-Username: CNetID
-Password: CNet password
-```
-
-Upon acceptance into the MScA program, a RCC user account will automatically be activated for you.  If all has gone according to plan, there is no action required to obtain an RCC user account.  However, if for whatever reason you believe your account has not been activated, please contact [help@rcc.uchicago.edu](mailto:help@rcc.uchicago.edu)
-
-**NOTE**: RCC does not store your CNet password and we are unable to reset your password.
-If you require password assistance, please see the [CNet Password Recovery](https://cnet.uchicago.edu/recertify/) webpage.
-
-### 2-Factor Authentication
-
-Follow the instructions on [https://2fa.rcc.uchicago.edu](https://2fa.rcc.uchicago.edu) to enroll into 2fa.
-
-### Connecting with SSH
-
-Access to RCC resources is provided via secure shell (SSH) login.  Most Unix-like operating systems (Mac OS X, Linux, etc) provide an ssh utility by default that can be accessed by typing the command **ssh** in a terminal window.
-
-To login to midway2 from a Linux or Mac computer, open a terminal and at the command line enter:
-
-```default
-$ ssh <CNetID>@midway2.rcc.uchicago.edu
-```
-
-Windows users will first need to download an ssh client, such as [PuTTY](http://www.chiark.greenend.org.uk/~sgtatham/putty/) or 
-
-```
-MobaXterm_
-```
-
-, which will allow you to interact with the remote Unix command line. Use the following information to set up your connection:
-
-```default
-Hostname: midway2.rcc.uchicago.edu
-Username: CNetID
-Password: CNet password
-```
-
-### Connecting with ThinLinc
-
-ThinLinc is a remote desktop server that can be used to connect to RCC systems and obtain a remote graphical user interface (GUI). RCC recommends that ThinLinc be used when running software that requires a GUI.
-
-**NOTE**: You can connect to RCC systems via the ThinLinc web client at [https://midway2.rcc.uchicago.edu](https://midway2.rcc.uchicago.edu). The performance will be slower, but no client download is necessary.
-
-There are some differences between the Mac OS X, Windows, and Linux clients, but for the most part, these steps should be followed:
-
-
-* Download and install the appropriate ThinLinc client here:
-[https://www.cendio.com/thinlinc/download](https://www.cendio.com/thinlinc/download)
-
-
-* Open the ThinLinc client and use the following information to set up your connection:
-
-```default
-Server: midway2.rcc.uchicago.edu
-Username: CNetID
-Password: CNet password
-```
-
-Your client should look similar to this:
-
-
-
-![image](./img/thinlinc-client.png)
-
-
-* The default setting for ThinLinc is for the client to open in a fullscreen window that fills “all monitors.” If you would prefer to work with ThinLinc from its own window, click *Options* from the initial login interface and then *Screen* to adjust your settings as desired. The following is an example of a setup that places the ThinLinc client in its own window:
-
-
-
-![image](./img/thinlinc-options.png)
-
-
-* *Optional*: You are also able to export local resources via ThinLinc. To do so, click *Options* from the initial login interface and then *Local Devices*. To adjust your settings for exporting the local file system, click *Details* next to *Drives*.
-
-
-
-![image](./img/thinlinc-local-resources.png)
-
-
-* Upon successfully logging in, you will be presented with an gnome desktop.
-Click with right mouse button anywhere on the desktop and select “Open Terminal” from the menu.
-
-
-
-![image](./img/thinlinc-desktop.png)
-
-With ThinLinc it is possible to maintain an active session after you have closed your connection to Midway.  To disconned from Midway but maintain an active session (e.g. when you log back into the ThinLinc client you will resume your remote session from where you left off), simply close the ThinLinc window. NOTE: You must have *End existing session* **unchecked** for this to occur.
-
-To exit ThinLinc and terminate your session completely, simply select *Logout* from the *Applications* menu.
-
-## Using the Midway Cluster
-
-The Midway compute cluster is a shared resource used by the entire University community. Sharing computational resources creates unique challenges:
-
-
-* Jobs must be scheduled in a fair manner.
-
-
-* Resource consumption needs to be accounted.
-
-
-* Access needs to be controlled.
-
-Thus, a **scheduler** is used to manage job submissions to the cluster.  RCC uses the [Slurm](http://slurm.schedmd.com) resource manager to schedule jobs and provide interactive access to compute nodes.
-
-For detailed information on running specific types of compute jobs, consult the pages [Using Midway](../../using-midway/index.md#using-midway) and [Running jobs on midway](../../running-jobs/index.md#running-jobs).  Software-specific information can be found on the RCC [Software](../../software/index.md#software) page.
-
-## Data Transfer, Storage, and Backup
-
-RCC maintains a petascale high-performance GPFS shared file system which is used for users’ home directories, shared project space, and high-throughput scratch space.
-
-### Transferring files
-
-RCC provides a number of methods for accessing and transferring data in/out of our systems. We recommend the scp protocol for transferring files to/from RCC systems. RCC hosts a managed Globus Online endpoint that can be used for moving very large amounts of data. When connecting from the UChicago network or through the UChicago VPN it is also possible to connect to the RCC file systems using SAMBA.
-
-Please see the [Data Transfer](../../data-transfer/index.md#data-transfer) page for more information on how to move files to/from Midway.
-
-### Persistent and Temporary Storage
-
-You will have access to three different storage locations on Midway.
-
-All users are given a home directory with a 30GB quota.  This location should be used for small files, code, etc.  It is located at `/home/$USER`.
-
-For large capacity storage, MScA has obtained a block of high-capacity storage located at `/project/msca/`.  Each MScA user is initially given a 10GB quota on their own subdirectory (`/project/msca/$USER)`.  If you require more space, please contact Gregory Guevara <[gguevara@uchicago.edu](mailto:gguevara@uchicago.edu)> with a description of your requirements and an estimate of how much storage you will require.  Storage quotas in `/project/msca` will be increased on a case-by-case basis and may require a monetary contribution by the user.
-
-Finally, you will have access to a high-performance filesystem mounted on `/scratch/midway2/$USER` which has a 100GB quota. This storage location is intended for SHORT-TERM STORAGE ONLY.
-
-**NOTE**: Your scratch directory is NOT backed up and should NOT be used for long-term storage. Files stored in your scratch space that are older than 2 weeks may be removed automatically, so please practice good data management.
-
-### Backups and Snapshots
-
-We all inadvertently delete or overwrite files from time to time.  Snapshots are automated backups that are accessible through a separate path.  Snapshots of a user’s home directory can be found in `/snapshots/\*/home/$USER/` where the subdirectories refer to the frequency and time of the backup, e.g. daily-2012-10-04.06h15 or hourly-2012-10-09.11h00.  More information about backups can be found in the [Snapshots](../../data-storage/index.md#snapshots) section of the [Data Storage](../../data-storage/index.md#data-storage) page.
-
-While snapshots are the preferred way to recover lost files, RCC also maintains an archival tape backup of data stored in `/project` and `/home` file systems for disaster recovery purposes only.
+See [Running Jobs on Midway](../midway23/midway_jobs_overview.md) for detailed documentation on how to run your own programs on the cluster once you've connected. 
 
 ## Software
 
-Many commonly used software packages and libraries have been installed on Midway for your use.  See the complete [Software Module List](../../software/modules/index.md#modules) for a list of all software installed on Midway.  For an overview of how to use Software Modules on Midway, consult the RCC [Software](../../software/index.md#software) documentation page.
+Many commonly used software packages and libraries have been installed on Midway for your use.  For an overview of how to use Software Modules on Midway, consult the RCC [Software](../midway23/software/midway_software_overview.md) documentation page.
 
 ## SAS
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -77,6 +77,9 @@ nav:
     - "Skyway": skyway/skyway_overview.md
   - "RCC User Policy": user_policy.md
   - "Glossary": glossary.md
+  - "Tutorials":
+    - KICP Tutorial: tutorials/kicp_tutorial.md
+    - MSCA Tutorial: tutorials/msca_tutorial.md
   - "Mistakes to Avoid": mistakes_to_avoid/list.md
   - "FAQ": 
     - Accounts and Allocations: FAQ/accounts_and_allocations_faq.md


### PR DESCRIPTION
Following #94 -- we had not transferred the KICP and MSCA tutorial pages to the new guide. This PR adds a tutorial section to the guide, with the transferred content. We had been planning to do this at some point, so we can have a place to add more video tutorials and other walkthroughs. 