### PR TITLE
Added the use of the accounts command

### DIFF
--- a/docs/midway23/request_and_manage_allocations.md
+++ b/docs/midway23/request_and_manage_allocations.md
@@ -1,5 +1,5 @@
 ## Checking Your SU Balance and Usage
-The rcchelp tool can be used to check account balances. After logging into Midway 2 or Midway 3, simply type:
+The `rcchelp` tool can be used to check account balances. After logging into Midway 2 or Midway 3, simply type:
 ```
 rcchelp balance
 ```
@@ -13,3 +13,21 @@ To see an overall summary of your usage, simply enter:
 ```
 rcchelp usage
 ```
+
+You can also use the command `accounts` to show the current usage and other information. For instance, the following two useful commands
+```
+accounts usage --accounts pi-[PI-CNetID] --byuser -p 2021-2022
+```
+and
+```
+accounts usage --accounts pi-[PI-CNetID] --byjob
+```
+show the current SU usage of individual users within the given period, and of individual jobs under the given PI account, respectively.
+
+For the complete list of available options for the command `accounts` you can simply run
+```
+accounts
+```
+
+!!! note
+    There are certain differences in the arguments and output of the `accounts` and `rcchelp` commands on Midway2 and Midway3. Attempts to make them consistent are underway.

--- a/docs/midway23/request_and_manage_allocations.md
+++ b/docs/midway23/request_and_manage_allocations.md
@@ -4,7 +4,7 @@ The `rcchelp` tool can be used to check account balances. After logging into Mid
 rcchelp balance
 ```
 
-If you are a member of multiple groups, this will display the allocations and usage for all your groups. The rcchelp balance command has a number of options for summarizing allocation usage. For information on these options, type
+If you are a member of multiple groups, this will display the allocations and usage for all your groups. The `rcchelp balance` command has a number of options for summarizing allocation usage. For information on these options, type
 ```
 rcchelp balance --help
 ```
@@ -13,21 +13,3 @@ To see an overall summary of your usage, simply enter:
 ```
 rcchelp usage
 ```
-
-You can also use the command `accounts` to show the current usage and other information. For instance, the following two useful commands
-```
-accounts usage --accounts pi-[PI-CNetID] --byuser
-```
-and
-```
-accounts usage --accounts pi-[PI-CNetID] --byjob
-```
-show the current SU usage of individual users, and of individual jobs under the given PI account, respectively.
-
-For the complete list of available options for the command `accounts` you can simply run
-```
-accounts
-```
-
-!!! note
-    There are certain differences in the arguments and output of the `accounts` and `rcchelp` commands on Midway2 and Midway3. Attempts to make them consistent are underway.

--- a/docs/midway23/request_and_manage_allocations.md
+++ b/docs/midway23/request_and_manage_allocations.md
@@ -16,13 +16,13 @@ rcchelp usage
 
 You can also use the command `accounts` to show the current usage and other information. For instance, the following two useful commands
 ```
-accounts usage --accounts pi-[PI-CNetID] --byuser -p 2021-2022
+accounts usage --accounts pi-[PI-CNetID] --byuser
 ```
 and
 ```
 accounts usage --accounts pi-[PI-CNetID] --byjob
 ```
-show the current SU usage of individual users within the given period, and of individual jobs under the given PI account, respectively.
+show the current SU usage of individual users, and of individual jobs under the given PI account, respectively.
 
 For the complete list of available options for the command `accounts` you can simply run
 ```

--- a/docs/midway23/software/apps_and_envs/python.md
+++ b/docs/midway23/software/apps_and_envs/python.md
@@ -55,14 +55,16 @@ with `conda env create --prefix=/path/to/new/environment -f environment.yml`.
 ## Managing Packages
 
 In the Anaconda distributions of Python, you should generally be using a personal environment to manage
-packages. Once you activate your environment, you can install packages with `conda install` or
-`pip install`. As per the advice of the Anaconda software authors, any  `pip install` packages
-should be installed after `conda install` packages.
+packages. Once you activate your environment
+```
+source activate [your-env]
+```
+you can install packages with `conda install` or `pip install` into this environment. As per the advice of the Anaconda software authors, any  `pip install` packages should be installed after `conda install` packages.
 
 
 ## Using Python
 
-On Midway, python can be launched, after loading a desired module, at the terminal with the command:
+On Midway, `python` can be launched, after loading a desired module, at the terminal with the command:
 
 ```default
 python
@@ -72,6 +74,10 @@ To leave the launched interactive shell, use:
 
 ```default
 exit()
+```
+or
+```default
+quit()
 ```
 
 If you already have a python script, use this command to run it:
@@ -123,11 +129,9 @@ you can use this command to get your IP address:
 
 ```
 HOST_IP=`/sbin/ip route get 8.8.8.8 | awk '{print $7;exit}'`
-OR
-HOST_IP=$(hostname -i)
 echo $HOST_IP
 ```
-which can be either `128.135.x.y`, or `10.50.x.y`.
+which can be either `128.135.x.y` (an external address), or `10.50.x.y` (on-campus address).
 
 **Step 3**: Launch Jupyter with:
 
@@ -135,35 +139,46 @@ which can be either `128.135.x.y`, or `10.50.x.y`.
     ```
     jupyter-notebook --no-browser --ip=$HOST_IP
     ```
+    or
+    ```
+    jupyter-lab --no-browser --ip=$HOST_IP
+    ```
 ===+ "Midway3"
     ```
     jupyter-notebook --no-browser --ip=$HOST_IP --port=15021
     ```
-    ???+ note
-        Jupyter on Midway3 typically requires you to specify a port in the range of 15000-30000. You can
-        generate a random number in this range:
-        ```
-        PORT_NUM=$(shuf -i15001-30000 -n1)
-        echo $PORT_NUM
-        ```
+    or
+    ```
+    jupyter-lab --no-browser --ip=$HOST_IP --port=15021
+    ```
 
-which will give you a URL with a token, for example,
-
-```default
-http://10.50.221.192:15021/?token=9c9b7fb3885a5b6896c959c8a945773b8860c6e2e0bad629
-```
-
-If there is a problem with the port, your browser will complain. In that case, please try the next available port
-with the flag `--port=<port number>`, or use the command `shuf`  above to get a random port number before launching
+If there is a problem with the port already in use, your browser will complain. In that case, please try the next available port with the flag `--port=<port number>`, or use the command `shuf`  to get a random port number
 ```
 PORT_NUM=$(shuf -i15001-30000 -n1)
-jupyter-notebook --no-browser --ip=$HOST_IP --port=$HOST_NUM
+```
+and launch the Notebook server as earlier
+```
+jupyter-notebook --no-browser --ip=$HOST_IP --port=$PORT_NUM
 ```
 
-**Step 4**: Open the returned URL in the browser on your local machine. Note that if you do
-not specify `--no-browser --ip=`, the web browser will be launched on the node and
+which will give you two URLs with a token, one with the external address `128.135.x.y`, and another with the on-campus address `10.50.x.y`, or your local host `127.0.0.0`. The on-campus address is only valid when you are connecting to Midway2 or Midway3 via VPN.
+
+```default
+http://128.135.167.77:15021/?token=9c9b7fb3885a5b6896c959c8a945773b8860c6e2e0bad629
+```
+
+Note that if you do not specify `--no-browser --ip=`, the web browser will be launched on the node and
 the URL returned cannot be used on your local machine.
 
+
+**Step 4**: Open a web browser on your local machine with the returned URLs.
+
+If you are using on-campus network or VPN, you can use copy and paste (or `Ctrl` + mouse click on) the URL with the external address, or the URL with the on-campus address into the address bar.
+
+As of April 2023: If you are on Midway2, you can open the URL with the external address without VPN. If you are on Midway3, you need to connect via VPN to open either URLs.
+
+
+<!--
 As of Feb 2023, this step may hang and you may get the `The site is not reachable` error from the browser.
 If this is the case, open another terminal window on your local machine and run (15021 is the $HOST_NUM in this example)
 
@@ -175,6 +190,7 @@ to your local host at port 15021. Note that the port number should be consistent
 You can find out the meaning for the arguments used in this command at [explainshell.com](https://explainshell.com).
 
 After successfully logging with 2FA as usual, you will be able to open the URL in the browser on your local machine.
+-->
 
 **Step 5**: To kill Jupyter, go back to the first terminal window where you launch Jupyter Notebook
 and press `Ctrl+c` and then confirm with `y` that you want to stop it.


### PR DESCRIPTION
This PR mentions the use of the accounts command to check SU balance and usage per user and per job over some period. This command is very useful and is the workhorse of rcchelp on midway2. Part of rcchelp on Midway3 also uses a version of accounts, the others are based on slurm-info. @pcarbo and former CS members have also suggested the use of this one several times on slack.