### PR TITLE
Update midway_partitions.md

### DIFF
--- a/docs/midway23/midway_partitions.md
+++ b/docs/midway23/midway_partitions.md
@@ -65,7 +65,7 @@ This table details the job limits of each partition, set via a Quality of Servic
     | Partition | Max Nodes Per User | Max CPUs Per User | Max Jobs Per User | Max Wall Time |
     |-----------|--------------------|-------------------|-------------------|---------------|
     | `caslake` | 100                | 4800              | 1000              | 36 H          |
-    | `gpu`     | None               | None              | 500               | 36 H          |
+    | `gpu`     | None               | None              | 12                | 36 H          |
     | `bigmem`  | 96                 | 192               | 10                | 36 H          |
     | `amd`     | 64                 | 128               | 200               | 36 H          |
 


### PR DESCRIPTION
The maximum number of jobs on the gpu partition is 12. Please check it using the command "rcchelp qos | grep ^gpu" on midway3.