### PR TITLE
Fixed the beagle3 qos info: max CPUs and GPUs

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,10 @@ Make a suggestion or report an issue: https://github.com/rcc-uchicago/user-guide
     ```
     pip install mkdocs-monorepo-material
     ```
+    or
+    ```
+    pip install mkdocs-monorepo-plugin
+    ```
 
 4. Edit content  
 Make whatever edits or additions to the user guide by editing the source markdown documents, located in `docs/`. (Editable canva infographics: [RCC Workflow](https://www.canva.com/design/DAFQE3SCdzw/66GWBkbNEc6RApV25ZTeVQ/edit?utm_content=DAFQE3SCdzw&utm_campaign=designshare&utm_medium=link2&utm_source=sharebutton), [Running Jobs Workflow](https://www.canva.com/design/DAFQom0o07g/YnCNw4zYkjFogxGr1dPZSw/edit?utm_content=DAFQom0o07g&utm_campaign=designshare&utm_medium=link2&utm_source=sharebutton)).

--- a/docs/beagle3/beagle3_overview.md
+++ b/docs/beagle3/beagle3_overview.md
@@ -25,9 +25,9 @@ You should contact your PI for access to Beagle3. You can also [contact our Help
 There are two quality-of-service (QoS) options available on the beagle3 partition. You can specify either one by using the --qos flag in your sbatch scripts or sinteractive commands.
 
 
---qos=beagle3: This QoS allows you to request up to 512 CPU-cores and 64 GPUs, and a maximum wall time of 48 hours. It is the default QoS for the beagle3 partition.
+`--qos=beagle3`: This QoS allows you to request up to 256 CPU-cores and 32 GPUs, and a maximum wall time of 48 hours. It is the default QoS for the beagle3 partition.
 
---qos=beagle3-long: This QoS allows you to request up to 128 CPU-cores and 16 GPUs, and a maximum wall time of 96 hours.
+`--qos=beagle3-long`: This QoS allows you to request up to 128 CPU-cores and 16 GPUs, and a maximum wall time of 96 hours.
 
 ## Connecting and Running Jobs
 


### PR DESCRIPTION
To correct the incorrect numbers as reported in #141 

Command to retrieve cpu, gres/gpu and node:

`sacctmgr show qos beagle3 --parsable`