### PR TITLE
Fixed gh deploy action failures with distutils not available with python 3.12

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,5 +12,5 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: 3.x
-      - run: pip install mkdocs-material mkdocs-monorepo-plugin
+      - run: pip install setuptools mkdocs-material mkdocs-monorepo-plugin
       - run: mkdocs gh-deploy --force --clean --verbose


### PR DESCRIPTION
distutils is deprecated in python 3.12 which is used by the gh deploy action, replaced by setuptools