### PR TITLE
Updated example script for NAMD 2.14, fixed broken links in some pages

### DIFF
--- a/docs/tutorials/kicp.md
+++ b/docs/tutorials/kicp.md
@@ -552,7 +552,7 @@ allowing us to peform further diagnostics if necessary. The parallel option `--r
 a walltime limit before all tasks have been completed. If you need to rerun a GNU Parallel job, be sure
 to delete **parallel.log** or it will think it has already finished!
 
-**NOTE**: More information may found in the RCC documentation section [Parallel batch jobs](../midway23/examples/example_job_scripts.md).
+**NOTE**: More information may found in the RCC documentation section [Parallel batch jobs](../slurm-sbatch.md#parallel-patch-jobs).
 
 ### Slurm Job Array
 
@@ -653,7 +653,7 @@ MaxJobsPU MaxSubmitPU
 
 The ability to submit array jobs which are larger than `MaxSubmitPU` is coming in a newer
 version of [Slurm](http://slurm.schedmd.com). Until then, each job should handle more than one piece of work, or the GNU Parallel
-solution should be used. For more information, see the RCC documentation section [Job arrays](../midway23/examples/example_job_scripts.md).
+solution should be used. For more information, see the RCC documentation section [Job arrays](../slurm-sbatch.md#job-arrays).
 
 #### Workflow Tools
 

--- a/docs/tutorials/msca.md
+++ b/docs/tutorials/msca.md
@@ -18,15 +18,15 @@ RCC support staff is available to assist with technical issues (help logging in,
 
 ## Logging into Midway
 
-For the most complete documentation regarding connecting to RCC resources see: [Connecting to Midway](../midway23/midway_connecting.md).
+For the most complete documentation regarding connecting to RCC resources see: [Connecting to Midway](../connecting.md).
 
 ## Using Midway
 
-See [Running Jobs on Midway](../midway23/midway_jobs_overview.md) for detailed documentation on how to run your own programs on the cluster once you've connected. 
+See [Running Jobs on Midway](../slurm.md) for detailed documentation on how to run your own programs on the cluster once you've connected. 
 
 ## Software
 
-Many commonly used software packages and libraries have been installed on Midway for your use.  For an overview of how to use Software Modules on Midway, consult the RCC [Software](../midway23/software/midway_software_overview.md) documentation page.
+Many commonly used software packages and libraries have been installed on Midway for your use.  For an overview of how to use Software Modules on Midway, consult the RCC [Software](../software/index.md) documentation page.
 
 ## SAS
 


### PR DESCRIPTION
After refactoring/reorganizing the pages, some pages still have links to older pages, such as `../midway23/examples/example_job_scripts.md` or `../midway23/midway_connecting.md`. This PR fixed the broken links in some of the pages. Need to continue to fix this for other pages.