### PR TITLE
Collective small fixes and updates

### DIFF
--- a/docs/databases/alphafold.md
+++ b/docs/databases/alphafold.md
@@ -1,0 +1,16 @@
+# AlphaFold/ColabFold datasets
+
+The datasets for [AlphaFold](https://github.com/google-deepmind/alphafold), [AlphaFold 3](https://github.com/google-deepmind/alphafold3) and [ColabFold](https://github.com/sokrypton/ColabFold) are available on Midway3. 
+
+The datasets contain Multiple Sequence Alignment (MSA) data (Unifref90, MGnify, BFD, Uniclust30) for identifying homologous sequences that align with the input sequences and structure templates (PDB70 and PDB100) for predicting structures of the input sequences.
+
+The paths to these datasets are as follows:
+
+|                | Path                                                                |
+|----------------|---------------------------------------------------------------------|
+| AlphaFold 2    | `/software/alphafold-data-2.3`                                      |
+| AlphaFold 3    | `/software/alphafold3.0-el8-x86_64/databases`                       |
+| ColabFold      | `/software/colabfold-data`                                          |
+
+Please contact the RCC to request for updating the datasets when necessary.  Example uses of these datasets with AlphaFold can be found in [AlphaFold](../software/apps-and-envs/alphafold.md).
+

--- a/docs/partitions.md
+++ b/docs/partitions.md
@@ -12,8 +12,8 @@ The typical output will include:
 
 | Column           | Description                                                         |
 |------------------|---------------------------------------------------------------------|
-| `AVAIL_FEATURES` | Available features such as CPUs, GPUs, and internode interfaces         |
-| `NODELIST`       | IDs of the compute nodes within the given partition                        |
+| `AVAIL_FEATURES` | Available features such as CPUs, GPUs, and internode interfaces     |
+| `NODELIST`       | IDs of the compute nodes within the given partition                 |
 | `NODES(A/I/O/T)` | Number of nodes by state in the format "allocated/idle/other/total" |
 | `S:C:T`          | Number of sockets, cores, and threads                               |
 

--- a/docs/software/apps-and-envs/alphafold.md
+++ b/docs/software/apps-and-envs/alphafold.md
@@ -1,22 +1,28 @@
 # Alphafold
 
-[AlphaFold](https://www.deepmind.com/research/highlighted-research/alphafold) is an artificial intelligence program developed by DeepMind, a subsidiary of Alphabet, which performs predictions of protein structure.
+[AlphaFold](https://www.deepmind.com/research/highlighted-research/alphafold) is an artificial intelligence program developed by Google DeepMind, a subsidiary of Alphabet, which performs predictions of protein structure.
 
 ## Available modules
 
-`Alphafold2` is available as modules on Midway3 that you can check via `module avail alphafold`.
+### AlphaFold 2
+
+AlphaFold 2 is available as modules on Midway3 that you can check via `module avail alphafold`.
 
 ```
 module avail alphafold
 ---------------------- /software/modulefiles----------------------------------
-alphafold/2.0.0(default)  alphafold/2.2.0  alphafold/2.3.2  
+alphafold/2.0.0(default)  alphafold/2.2.0  alphafold/2.3.2
 ```
 
 The AlphaFold source code and running scripts (e.g. `run_alphafold.py`) can be found at the Alphafold [GitHub](https://github.com/deepmind/alphafold).
 
 The training data sets for different versions of Alphafold are accessible under `/software/alphafold-data/`, `/software/alphafold-data-2.2/` and `/software/alphafold-data-2.3/`.
 
-## Example job script
+### AlphaFold 3
+
+AlphaFold 3 uses a container-based approach and requires different input arguments. See the example job script below.
+
+## Example job scripts
 
 Typically, Alphafold2 uses [OpenMM](https://openmm.org/), a GPU-accelerated molecular simulation package, to relax the candidate protein. OpenMM requires the CUDA toolkit to run on a GPU node.
 
@@ -46,7 +52,7 @@ echo "CPU cores: $SLURM_CPUS_PER_TASK"
 
 DOWNLOAD_DATA_DIR=/software/alphafold-data-2.3
 
-python run_alphafold.py  \
+python run_alphafold.py \
   --data_dir=$DOWNLOAD_DATA_DIR  \
   --uniref90_database_path=$DOWNLOAD_DATA_DIR/uniref90/uniref90.fasta  \
   --mgnify_database_path=$DOWNLOAD_DATA_DIR/mgnify/mgy_clusters_2022_05.fa  \
@@ -61,5 +67,50 @@ python run_alphafold.py  \
   --use_gpu_relax=true \
   --output_dir=out_alphafold_2.1.1_multi-monomer \
   --fasta_paths=T1083.fasta,T1084.fasta
+
+```
+
+For AlphaFold 3, suppose that you have downloaded a .json file that defines the sequences for the calculation, for instance, 
+[nipah_zmr.json](https://www.rbvi.ucsf.edu/chimerax/data/af3-wynton-dec2024/nipah_zmr.json) and put the downloaded json file under `/home/$USER`.
+
+```
+#!/bin/bash
+#SBATCH --job-name=alphafold3
+#SBATCH --account=[your-accountname]
+#SBATCH --partition=gpu
+#SBATCH --nodes=1
+#SBATCH --time=04:00:00
+#SBATCH --ntasks-per-node=1
+#SBATCH --cpus-per-task=16
+#SBATCH --gres=gpu:2
+#SBATCH --constraint=a100
+#SBATCH --mem=32G
+
+module load apptainer
+
+cd $SLURM_SUBMIT_DIR
+
+mkdir -p /tmp/$USER
+
+DOWNLOAD_DATA_DIR=/software/alphafold3.0-el8-x86_64/databases
+
+BIND_PATHS="/software/alphafold3.0-el8-x86_64/databases,/software/alphafold3.0-el8-x86_64/params,/software/alphafold3.0-el8-x86_64/singularity,/tmp/$USER,/home/$USER,/scratch/midway3/$USER"
+
+# Run the Singularity container `alphafold3.sif` provided under `/software/alphafold3.0-el8-x86_64` with the .json file:
+
+singularity exec --nv \
+    -B "$BIND_PATHS" \
+    --env CUDA_VISIBLE_DEVICES=0,1,NVIDIA_VISIBLE_DEVICES=0,1 \
+    /software/alphafold3.0-el8-x86_64/alphafold3.sif \
+    python /app/alphafold/run_alphafold.py \
+    --json_path=/home/$USER/nipah_zmr.json \
+    --db_dir=$DOWNLOAD_DATA_DIR \
+    --output_dir=/scratch/midway3/$USER/alphafold3_output \
+    --model_dir=/software/alphafold3.0-el8-x86_64/params \
+    --flash_attention_implementation=triton \
+    --run_data_pipeline=True \
+    --run_inference=True \
+    --jackhmmer_n_cpu=8 \
+    --nhmmer_n_cpu=8
 
 ```

--- a/docs/storage/main.md
+++ b/docs/storage/main.md
@@ -1,6 +1,6 @@
 # System Layout
 
-Midway2,  Midway3, and Beagle3 have a high-performance GPFS shared file system that houses private **home** directories, shared **project**, **project2**, and **beagle3** spaces, and high-throughput **scratch** space. The shared and scratch directories of Midway2, Midway3, and Beagle3 are 'cross-mounted', meaning that they are accessible from system-specific login and compute nodes. However, `/home`, `/software`, and `/snapshots` are specific to each cluster and their respective login nodes.
+Midway2,  Midway3, and Beagle3 have a high-performance GPFS shared file system that houses private **home** directories, shared **project**, **project2**, and **beagle3** spaces, and high-performance **scratch** space. The shared and scratch directories of Midway2, Midway3, and Beagle3 are 'cross-mounted', meaning that they are accessible from system-specific login and compute nodes. However, `/home`, `/software`, and `/snapshots` are specific to each cluster and their respective login nodes.
 
 <p align='center'>
 <img src='../../img/data_management/midway23_storage.jpeg'

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -59,8 +59,9 @@ nav:
     - Developer Tools: software/dev-tools.md
 
   - 'Databases': 
-    - BFI: databases/bfi.md 
-    - Booth: databases/booth.md 
+    - AlphaFold: databases/alphafold.md
+    - BFI: databases/bfi.md
+    - Booth: databases/booth.md
 
 
   - "Tutorials":


### PR DESCRIPTION
This PR fixed a typo in the scratch storage page (`high-performance` instead of `high-throughput`), per ticket 65224, and included the AlphaFold/ColabFold datasets; and updated the AlphaFold software page with AlphaFold 3 example.