### PR TITLE
Improve SCode Documentation: .bashrc Tips, CLI extention Installation, and Info Boxes

### DIFF
--- a/docs/software/apps-and-envs/scode/extensions.md
+++ b/docs/software/apps-and-envs/scode/extensions.md
@@ -4,57 +4,9 @@ This guide explains how to manage Visual Studio Code extensions in server-based 
 
 ---
 
-## Option 1: Install Extensions via the VSCode Web UI
+## Option 1: Install Extensions via CLI (Recommended)
 
-This is the recommended method for installing a few extensions manually. If a large number of extensions are needed, consider using [Option 2](#option-2-install-extensions-via-cli) and [Option 3](#option-3-porting-extensions-from-an-existing-vscode-installation).
-
-### Step 1: Download the Extension (.vsix)
-
-**Method A**: From local VSCode
-
-1. Open VSCode on your local machine
-2. [Optional] Connect to the Midway cluster via SSH
-3. Go to the **Extensions Panel** (left sidebar)
-4. Search for the desired extension (e.g., `Python`, `Jupyter`)
-5. Right-click the extension and select **"Download VSIX"** to save the `.vsix` file locally.
-
-![Download VSIX](./images/download_vsix.png){: class="responsive-img"}
-
-**Method B**: From the VSCode Server Web UI
-
-1. Open your VSCode Web UI in the browser
-2. Go to the **Extensions Panel**
-3. Search for the desired extension
-4. Click the **Install**. VSCode will complain that an internet error prevented a successful installation.
-5. Click the **"Try Downloading Manually..."** link to download the `.vsix` file to your local machine.
-
-![Download VSIX from Web UI](./images/manual_download.png){: class="responsive-img"}
-
-### Step 2: Transfer the Extension to the Server
-
-If you downloaded the `.vsix` file to your local machine, you will need to transfer it to the Midway cluster:
-
-**Method A**: Drag and drop the local `.vsix` file to the VSCode UI.
-**Method B**: Use `scp` to copy the file to the cluster.
-
-```bash
-scp path/to/vsix/file <yourusername>@<midway_ssh_host>:~
-```
-
-### Step 3: Install from VSIX
-
-1. Open your VSCode Web UI in the browser
-2. Go to the **Extensions Panel** (left sidebar)
-3. Click the **three-dot menu (⋮)** in the top-right corner of the panel
-4. Choose **"Install from VSIX"**, and select the file from your home directory
-
-![Install from VSIX](./images/install_from_vsix.png){: class="responsive-img"}
-
----
-
-## Option 2: Install Extensions via CLI
-
-If you are automating setup or managing multiple environments, you can use the `scode` CLI:
+The easiest way to install extensions for the VSCode Server is via the `scode` CLI **from a login node**:
 
 ```bash
 scode ext install ms-python.python ms-toolsai.jupyter
@@ -63,19 +15,21 @@ scode ext install ms-python.python ms-toolsai.jupyter
 You can use the `--env` option to specify the environment name (e.g., `default`).
 
 To list environments or identify the current environment:
+
 ```bash
 scode list
 ```
 
 ---
 
-## Option 3: Porting Extensions from an Existing VSCode Installation
+## Option 2: Porting Extensions from an Existing VSCode Installation
 
-If you have a local setup with useful extensions, you can export and re-import them in the server environment.
+If you already have a working VSCode installation on your local machine, you can export and re-import them to your `scode` environment.
 
 ### Step 1: Export locally
 
 On your **local machine**:
+
 ```bash
 code --list-extensions > extensions.txt
 ```
@@ -93,25 +47,77 @@ If you are using VSCode Insiders:
 code-insiders --list-extensions > extensions.txt
 ```
 
-If you need specific versions of extensions, you can modify the file to include version numbers like this:
+If you need specific versions of extensions, you can use `--show-versions` to include extension version numbers:
+
 ```bash
 code --list-extensions --show-versions > extensions.txt
 ```
 
 ### Step 2: Upload to the cluster
 
-You can manually copy the contents of `extensions.txt` to the Midway cluster, or use `scp`:
+You can manually copy the contents of `extensions.txt` to the Midway cluster using clipboard and `nano`.
+
+Alternatively, you can also use `scp` to copy the `extensions.txt` to your home directory:
 
 ```bash
-scp extensions.txt yourusername@midway3.rcc.uchicago.edu:~
+scp extensions.txt <yourusername>@midway3.rcc.uchicago.edu:~
 ```
 
-### Step 3: Bulk install in server environment
+### Step 3: Installing extensions from a text file
+
+Running this command **on a login node** will install all extensions listed in the file, essentially replicating your local VSCode environment.
+
 ```bash
 scode ext install -f extensions.txt
 ```
 
-This command installs all extensions listed in the file.
+!!! note
+
+    It is possible to create an `extensions.txt` manually. Extensions IDs such as [`ms-python.python`](https://marketplace.visualstudio.com/items?itemName=ms-python.python) and [`ms-toolsai.jupyter`](https://marketplace.visualstudio.com/items?itemName=ms-toolsai.jupyter) can be found on the [VSCode Extension Marketplace](https://marketplace.visualstudio.com/vscode).
+
+---
+
+## Option 3: Install Extensions Manually via the VSCode Web UI
+
+This method is not recommended due to its complexity, but it can work as an expedient way for installing one or two extensions on the fly.
+
+### Step 1: Download the Extension (`.vsix`) To Your Local Machine
+
+**From a running `scode` session** (if you already have the VSCode Server Web UI started with `scode`)
+
+1. Open your VSCode Web UI in the browser
+2. Go to the **Extensions Panel**
+3. Search for the desired extension
+4. Click the **"Install"** button. VSCode will complain that an internet error prevented a successful installation
+5. Click **"Try Downloading Manually..."** to download the `.VSIXPackage` file to your local machine
+
+![Download VSIX from Web UI](./images/manual_download.png){: class="responsive-img rounded"}
+
+**From your local machine** (If you haven't had the Web UI set up with `scode`)
+
+1. Open the VSCode application **on your local machine**
+2. [Optional] Connect to the Midway cluster via SSH
+3. Go to the **Extensions Panel** (left sidebar)
+4. Search for the desired extension (e.g., `Python`, `Jupyter`)
+5. Right-click the extension and select **"Download VSIX"** to save the `.VSIXPackage` file locally
+
+![Download VSIX](./images/download_vsix.png){: class="responsive-img rounded"}
+
+### Step 2: Installing the `.vsix` file
+
+!!! warning inline end
+
+    VSCode saves extension files as `.VSIXPackage` by default. You **MUST** rename the extension to `.vsix` in lowercase to make it installable from the Web UI.
+
+1. Open your VSCode Web UI in the browser
+2. **Rename the `.VSIXPackage` file extension to `.vsix`**
+3. Go to the **Extensions Panel** (left sidebar)
+4. Click the **three-dot menu (⋮)** in the top-right corner of the panel
+5. Choose **"Install from VSIX..."**
+6. Click **"Show Local"** on the top right of the file selector
+7. Select the `.vsix` file from your local machine and wait for the installation to complete
+
+![Install from VSIX](./images/install_from_vsix.png){: class="responsive-img rounded"}
 
 ---
 
@@ -124,6 +130,8 @@ scode ext list
 ```
 
 ### Update all extensions
+
+You can run the `update` command periodically to keep your extensions up to date:
 
 ```bash
 scode ext update
@@ -139,6 +147,7 @@ scode ext uninstall ms-python.python ms-toolsai.jupyter
 
 ## Notes
 
-- Always confirm you are working in the correct environment, use `--env` option if you wish to interact with a specific environment.
+-  **When installing new extensions while the VSCode server is running**, you may need to run **Reload Window** from the VSCode command palette, or restart the `scode` job for the changes to take effect.
+- Always confirm you are working in the correct environment by running `scode list`, use `--env` option if you wish to interact with a specific environment.
 - If you are **serving a non-latest version of VSCode** by specifying `--version` with `serve-web`, you may need to specify a matching `--cli-version` when running `scode ext install` to ensure extension compatibility. **It is recommended to always use the latest version of VSCode Server** unless needed.
 - For more help, run `scode ext --help`.

--- a/docs/software/apps-and-envs/scode/main.md
+++ b/docs/software/apps-and-envs/scode/main.md
@@ -14,44 +14,92 @@ To install extensions, see the [Extension Installation Guide](./extensions.md). 
 
 ## Quick Start
 
-| Steps                          | Commands                                                                         |
-| ----------------------------- | ------------------------------------------------------------------------------- |
-| Load SCode module             | `module load scode`                                                             |
-| Launch VSCode Server             | `scode serve-web -- --account <pi-account> --time 01:00:00 --mem 16G` |
-| List jobs and get job ID     | `scode jobs list`                                                               |
-| Check status and get conncection instructions | `scode jobs status <job_id>`                                                    |
-| Cancel a job                  | `scancel <job_id>`                                                              |
-
+| **Step**   | **Description**                                                                                   | **Command / Action**                                                  | **Run On**       |
+| ---------- | ------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- | ---------------- |
+| **Step 1** | [Load `scode` & install necessary extensions](#step-1-setting-up-scode)                                               | `module load scode` <br/> `scode ext install ms-python.python ms-toolsai.jupyter`            | 🔐 Login Node    |
+| **Step 2** | [Launch VSCode Server](#step-2-launch-a-vscode-server)                                            | `scode serve-web -- --account <pi-account> --time 01:00:00 --mem 16G` | 🔐 Login Node    |
+| **Step 3** | [Check job status & get connection info](#step-3-check-job-status)                                | `scode jobs status <job_id>`                                          | 🔐 Login Node    |
+| **Step 4** | [Create SSH tunnel from your local machine](#step-4-create-an-ssh-tunnel-from-your-local-machine) | Follow the SSH command printed in **Step 3**                          | 💻 Local Machine |
+| **Step 5** | [Access VSCode in your browser](#step-5-access-vscode-in-your-browser)                          | Open the web link provided in **Step 3**                              | 💻 Local Machine |
+| **Step 6** | [End the session](#step-6-ending-the-session)                                                     | `scancel <job_id>`                                                    | 🔐 Login Node    |
 
 ---
 
-## Step 1: Load `scode` Module
+## Step 1: Setting Up `scode`
 
-Before using `scode`, load the module in your terminal:
+### Step 1.1: Loading the `scode` Module
+
+In order to run the `scode` command, first load the `scode` module **from a login node**:
 
 ```bash
 module load scode
 ```
 
-This will activate the `scode` command in your environment. You can add this command to your `.bashrc` or `.bash_profile` for automatic loading in future sessions.
+This will activate the `scode` command in your environment. You can add this command to your `~/.bashrc` or `~/.bash_profile` for automatically loading `scode` in future sessions.
 
 ```bash
 echo "module load scode" >> ~/.bashrc
 source ~/.bashrc # Reload the shell configuration
 ```
 
+??? question "What is a `.bashrc` file?"
+
+    The `.bashrc` file is your personal script that automatically configures your environment every time you open a new terminal.
+  
+    | File Name          | Scope         | When It’s Executed                            | Common Use Cases                                                                      |
+    | ------------------ | ------------- | --------------------------------------------- | ------------------------------------------------------------------------------------- |
+    | `/etc/bash.bashrc` | System-wide   | For every user’s interactive, non-login shell | Set default aliases and functions for all users on the system.                        |
+    | `~/.bashrc`        | User-specific | For a user’s interactive, non-login shells    | The main file for personal aliases, functions, and prompt customizations.             |
+    | `~/.bash_profile`  | User-specific | For a user’s login shell                      | Set environment variables and run commands that only need to happen once per session. |
+    | `~/.profile`       | User-specific | Fallback for `~/.bash_profile`                | A more generic version that can be used by other shells, not just Bash.               |
+
+    For your day-to-day terminal customizations like aliases and prompt settings, `~/.bashrc` is the correct file to edit.
+
+### Step 1.2: `~/.bashrc` Environment Setup
+
+To use `scode` and other tools effectively in VSCode Server, It is recommended to have your environment correctly initialized by modifying your `~/.bashrc`.
+
+```bash
+# ~/.bashrc
+export MY_VAR="HelloWorld"
+module load python/anaconda-2023.09
+```
+
+This will ensure that necessary environment variables and system modules such as `python`, `cuda` and `java` are available in both the terminal and within VSCode extensions.
+
+!!! tip
+
+    VSCode Server automatically sources `~/.bashrc` at startup. A properly set up `~/.bashrc` can help:
+    
+    - VSCode `Python` extension to detect and use the correct `Python` versions.
+    
+    - The integrated terminal to use your configured modules and environment variables.
+
+### Step 1.3: Install Necessary VSCode Extensions
+
+To take full advantage of language features in VSCode (e.g., autocompletion, linting, Jupyter notebook support), you can install the relevant extensions using `scode` before [starting the server](#step-2-launch-a-vscode-server).
+
+For instance, for Python developments, run the following command **on the login node**:
+
+```bash
+scode ext install ms-python.python ms-toolsai.jupyter
+```
+
+For more details, see the [Extension Installation Guide](./extensions.md).
+
 ---
 
 ## Step 2: Launch a VSCode Server
 
-Once the module is loaded, you can submit a job to start a VSCode Web server. Run the following command from your login node:
+Once the module is loaded, you can submit a job to start a VSCode Web server. Run the following command **from a login node**:
 
 ```bash
 scode serve-web -- --account <pi-account> --time 01:00:00 --partition caslake --mem 16G
 ```
 
-- `<pi-account>`: Replace this with the name of your PI or course account. Use commands such as `id` and `accounts list` to check the accounts you are a member of.
-- Additional slurm options can be added to the `scode serve-web` command after the `--` separator. Refer to [Slurm User Guide](../../../slurm/sbatch.md) and [Sbatch Documentation](https://slurm.schedmd.com/sbatch.html) for more details on job submission options.
+- `<pi-account>`: Replace this with the name of your Principal Investigator (PI) or course account. This account will be used to provision compute nodes in the specified partition.
+- To view the accounts you are associated with and check available allocations, use `groups`, `accounts list` and `accounts balance`. Refer to the documentation for [`groups`](../../../partitions.md#what-partitions-i-can-use) and [`accounts`](../../../101/allocations.md#how-do-i-check-how-many-service-units-i-have-remaining-on-my-allocation) commandline utilities for more details.
+- Additional slurm options can be added to the `scode serve-web` command **after the standalone `--` separator**. Refer to [Slurm User Guide](../../../slurm/sbatch.md) and [Sbatch Documentation](https://slurm.schedmd.com/sbatch.html) for more details on job submission options.
 
 This command will:
 
@@ -61,7 +109,7 @@ This command will:
 
 Example output:
 
-```
+```bash
 Submitting SBATCH to serve VSCode environment.
 
 Submitted batch job 30317404
@@ -70,12 +118,12 @@ sbatch: Verify job submission ...
 sbatch: Using a shared partition ...
 sbatch: Partition: caslake
 sbatch: QOS-Flag: caslake
-sbatch: Account: pi-account
+sbatch: Account: <pi-account>
 sbatch: Verification: ***PASSED***
 
-SBATCH job /home/yourusername/.scode/sbatches/scode-web_20250409_101953.sbatch submitted successfully.
-Output will be directed to /home/yourusername/.scode/logs/scode-web_30317404.out.
-Errors will be directed to /home/yourusername/.scode/logs/scode-web_30317404.err.
+SBATCH job /home/<yourusername>/.scode/sbatches/scode-web_20250409_101953.sbatch submitted successfully.
+Output will be directed to /home/<yourusername>/.scode/logs/scode-web_30317404.out.
+Errors will be directed to /home/<yourusername>/.scode/logs/scode-web_30317404.err.
 VSCode server is starting with Slurm Job ID 30317404.
 Use `scode jobs status 30317404` to check the status of the server.
 Use `scancel 30317404` to cancel the server job.
@@ -85,7 +133,7 @@ Use `scancel 30317404` to cancel the server job.
 
 ## Step 3: Check Job Status
 
-To view active VSCode Server jobs:
+To view active VSCode Server jobs, run the following command **on the login node**:
 
 ```bash
 scode jobs list
@@ -101,29 +149,30 @@ If the job is running, you will receive detailed connection instructions.
 
 Example output:
 
-```
+```bash
 VSCode job 30317404 is running on 1 nodes: midway3-0024
 Primary node: 10.50.250.24
-Environment: /home/yourusername/.scode/envs/stable/default
+Environment: /home/<yourusername>/.scode/envs/stable/default
 
 
 To connect to the VSCode Web GUI you need to create an SSH tunnel from your local machine to the primary node above. This can be done with the following command to be run on your local machine (e.g., PowerShell in Windows):
 
-    ssh -L 8000:10.50.250.24:61028 yourusername@midway3.rcc.uchicago.edu
+    ssh -L 8000:10.50.250.24:61028 <yourusername>@midway3.rcc.uchicago.edu
 
 Once the tunnel is created, you may access the VSCode Web GUI by entering the following address in your browser:
 
     http://localhost:8000/?tkn=f1c72d89-4a5e-43d2-ae1b-9b8237dce021
 
-Server outputs are being written to /home/yourusername/.scode/logs/scode-web_30317404.out.
-Server errors are being written to /home/yourusername/.scode/logs/scode-web_30317404.err.
+Server outputs are being written to /home/<yourusername>/.scode/logs/scode-web_30317404.out.
+Server errors are being written to /home/<yourusername>/.scode/logs/scode-web_30317404.err.
 You may use `squeue -j 30317404` to see more information about this job, or cancel it with `scancel 30317404`.
 ```
 
 In this output:
 
-- `8000` is a port on your local machine. All traffic to this port will be forwarded to the remote VSCode Web server with SSH tunnel. You can change this port if it is already in use.
-- `61028` is the port on the remote server where the VSCode Web server is running, which is randomly assigned by SCode.
+- `8000` is a port **on your local machine**. All traffic to this port will be forwarded to the remote VSCode Web server with SSH tunnel. You can change this port if it is already in use.
+- `61028` is the port **on the compute node** where the VSCode Web server is running, which is randomly assigned by SCode.
+- When running `scode jobs status 30317404`, scode will automatically fill in `<yourusername>` and the ssh endpoint for you (in this example, `midway3.rcc.uchicago.edu`), so that you can directly copy and run the tunnelling command in your local terminal.
 
 ---
 
@@ -132,7 +181,7 @@ In this output:
 On your **local machine**, open another terminal, and run the SSH command shown in the job status output. For example:
 
 ```bash
-ssh -L 8000:10.50.250.24:61028 yourusername@midway3.rcc.uchicago.edu
+ssh -L 8000:10.50.250.24:61028 <yourusername>@midway3.rcc.uchicago.edu
 ```
 
 This command creates a secure channel between port `8000` on your local computer and the remote VSCode Web server running inside the cluster.
@@ -144,15 +193,15 @@ This command creates a secure channel between port `8000` on your local computer
 
 ---
 
-## Step 5: Access VSCode in Your Browser
+## Step 5: Access VSCode In Your Browser
 
-Once the SSH tunnel is active, follow the link from `scode jobs status`:
+Once the SSH tunnel is active, open up a browser session **on your local machine** and follow the link from `scode jobs status`:
 
 ```
 http://localhost:8000/?tkn=f1c72d89-4a5e-43d2-ae1b-9b8237dce021
 ```
 
-Modify port `8000` if you used a different local port in `Step 4`.
+Modify port `8000` if you used a different local port in **Step 4**.
 
 You will be redirected to a fully functional VSCode Web interface running on the cluster, within your compute environment.
 
@@ -163,7 +212,7 @@ You will be redirected to a fully functional VSCode Web interface running on the
 When you are done:
 
 - Close the browser tab (to avoid dangling temp files in your home directory)
-- Optionally cancel the SLURM job manually to avoid resource misuse:
+- Cancel the SLURM job:
 
 ```bash
 scancel 30317404

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -41,3 +41,10 @@ img.responsive-img {
     padding: 0 5px;
   }
 }
+
+/* rounded image */
+
+img.rounded {
+  border-radius: 8px;
+  box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2), 0 6px 20px 0 rgba(0, 0, 0, 0.19);
+}


### PR DESCRIPTION
- [Add guides for `.bashrc` and basic VSCode extension setup](https://github.com/rcc-uchicago/user-guide/commit/c514c5c16e70eecf619ae9697c930b65af025252)
- [Reorder extension installation guide, placing the recommended CLI method on top](https://github.com/rcc-uchicago/user-guide/commit/2ea608f2bb58d3d5d5745edf3e3bb5768a7f5b72)
- Added various informational callouts for improved clarity

**Todo:**

- Add a tested Python/Jupyter setup guide with `scode` to help potential users transition from jupyter notebooks
- Add a environment management page to inform user of the `default` environment and possible commands to create more