### PR TITLE
docs: add slurmwatch for live job monitoring (Midway3 module)

### DIFF
--- a/docs/slurm/sbatch.md
+++ b/docs/slurm/sbatch.md
@@ -222,7 +222,27 @@ scancel --user=<CNetID>
 ```
 
 ### Monitoring running jobs
-You can monitor your job by connecting to the compute node it runs on via `SSH` and using the `htop` command.
+
+#### With `slurmwatch`
+
+[`slurmwatch`](https://github.com/PursuitOfDataScience/slurmwatch) shows the live CPU, memory, and GPU usage of a running job — counting only *your* processes — as a terminal dashboard, so you can see at a glance whether the job is using the resources you requested. It is available as a module on Midway3:
+
+```
+module load slurmwatch
+slurmwatch <jobID>      # watch a specific job
+slurmwatch              # or auto-discover your running job
+```
+
+Run from a login node, `slurmwatch` attaches to the compute node your job is on automatically (no manual `ssh` needed) and updates a few times per second. Press `c`, `m`, or `g` for a full-screen CPU / memory / GPU view, and `q` to quit. Unlike `htop`, it isolates your job's own processes and also reports GPU utilization and VRAM, which is useful on the GPU partitions.
+
+!!! tip
+    For an interactive session, run `slurmwatch` in a second pane on the compute node (e.g. with `tmux`) so it watches your work without getting in the way — see [Interactive jobs](./sinteractive.md#monitoring-an-interactive-session).
+
+See the [slurmwatch README](https://github.com/PursuitOfDataScience/slurmwatch#readme) for the full set of keys and options.
+
+#### With `SSH` and `htop`
+
+Alternatively, you can monitor your job by connecting to the compute node it runs on via `SSH` and using the `htop` command.
 
 To do this, run the following to see your running jobs and which compute nodes your jobs are running on:
 ```

--- a/docs/slurm/sinteractive.md
+++ b/docs/slurm/sinteractive.md
@@ -132,6 +132,18 @@ mpirun -np 8 /project/[pi-folder]/[your-cnetid]/lammps/build/lmp -in melt/in.mel
 
 The run will produce the LAMMPS screen output and a file named `log.lammps` in the current folder.
 
+### Monitoring an interactive session
+
+While your session is running, you can watch its CPU, memory, and GPU usage live with [`slurmwatch`](https://github.com/PursuitOfDataScience/slurmwatch). Because an interactive session uses a single shell, run it in a second pane on the **same compute node** (for example, with `tmux`) so it watches your work without getting in the way:
+
+```
+module load slurmwatch
+tmux            # open a second pane, then:
+slurmwatch      # in one pane; run your program in the other
+```
+
+It watches the whole job, so it keeps reporting as you run one program, edit your code, and run another — there is no need to restart it between runs. Running it on the node reads usage directly and adds no extra Slurm step, so it will not interfere with your `srun`/`mpirun` launches. See [Monitoring running jobs](./sbatch.md#monitoring-running-jobs) for more.
+
 To terminate the interactive session, run
 
 ```


### PR DESCRIPTION
Adds `slurmwatch` to the job-monitoring documentation. It is installed as a module on Midway3 (`module load slurmwatch` → `slurmwatch/0.8.2(default)` under `/software/modulefiles`) and shows live per-process CPU / memory / GPU usage of a running job as a terminal dashboard.

**Changes**
- **`slurm/sbatch.md` → "Monitoring running jobs"**: lead with `slurmwatch` (`module load` + basic usage, and why it complements `htop` — it isolates your job's own processes, reports GPU utilization/VRAM, and hops to the compute node automatically), keeping the existing SSH + `htop` method as the alternative.
- **`slurm/sinteractive.md`**: new "Monitoring an interactive session" subsection with the recommended pattern — run it in a second `tmux` pane on the compute node so it watches your work without creating a contending Slurm step.

The two pages cross-link; no nav change.

Tool repo: https://github.com/PursuitOfDataScience/slurmwatch